### PR TITLE
Remove ember deploy slack notification

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -16,23 +16,9 @@ module.exports = function(deployTarget) {
     allowOverwrite: true
   };
 
-  ENV.slack = {
-    // Needs to be hardcoded and cannot be imported from env for security purpose
-    webhookURL: process.env.SLACK_DEPLOY_URL,
-    channel: '#github',
-    username: 'ember-cli-deploy'
-  }
-
   if (deployTarget === 'development') {
     ENV.build.environment = 'development';
     // configure other plugins for development deploy target here
-    ENV.slack.didDeploy = function(context) {
-      return function(slack) {
-        return slack.notify({
-          text: 'Deployed development frontend!'
-        });
-      };
-    }
   }
 
   if (deployTarget === 'staging') {
@@ -43,14 +29,6 @@ module.exports = function(deployTarget) {
       distribution: 'E2YVUU4RPYNUI2',
       objectPaths: ['/*']
     }
-
-    ENV.slack.didDeploy = function(context) {
-      return function(slack) {
-        return slack.notify({
-          text: 'Deployed staging frontend!'
-        });
-      };
-    }
   }
 
   if (deployTarget === 'production') {
@@ -59,14 +37,6 @@ module.exports = function(deployTarget) {
 
     ENV.cloudfront = {
       distribution: 'E1SR2PB8XTR9RC'
-    }
-
-    ENV.slack.didDeploy = function(context) {
-      return function(slack) {
-        return slack.notify({
-          text: 'Deployed production frontend!'
-        });
-      };
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-cli-deploy-revision-data": "0.3.2",
     "ember-cli-deploy-s3": "0.4.0",
     "ember-cli-deploy-s3-index": "0.5.0",
-    "ember-cli-deploy-slack": "0.1.0",
     "ember-cli-document-title": "0.3.3",
     "ember-cli-dotenv": "1.2.0",
     "ember-cli-emblem": "0.8.2-beta.2",


### PR DESCRIPTION
This fixes the deploy command which has been broken since the removal of Slack webhook URL.

A possible alternative to this PR is to export the `webhookURL` as environment before ember deploy.