### PR TITLE
Adds whitelabel theme

### DIFF
--- a/app/router.coffee
+++ b/app/router.coffee
@@ -5,6 +5,8 @@ Router = Ember.Router.extend
   location: ENV.locationType
   rootURL: ENV.rootURL
 
+Ember.$('body').addClass('theme-' + ENV.whitelabel.theme)
+
 Router.map ->
   @route 'freestyle'
   @route 'login'

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -1901,3 +1901,22 @@ input:checked + .slider:before
   .fa-font-size
     i
       margin-top: 5px!important
+
+.theme-light
+  .side-menu
+    background-color: #FFFFFF
+    .menu-list a
+      color: #6B6B6B
+      &:hover, &:active, &:focus
+        color: #414651
+        background-color: lighten(#ededed, 3%)
+      &.active, &.active:hover, &.active:active, &.active:focus
+        background-color: #ededed
+        color: #414651
+    .menu-label
+      background-color: lighten(#ededed, 3%)
+      color: #6b6b6b
+  .auth-main-container
+    background-color: #FFFFFF
+    .has-text-centered h6
+      color: #6B6B6B

--- a/app/templates/components/img-logo.emblem
+++ b/app/templates/components/img-logo.emblem
@@ -1,6 +1,6 @@
 = link-to 'authenticated.index'
   if env.isAppknox
-    if env.isEnterprise and env.whitelabel.logo
+    if env.whitelabel.logo
       img src=env.whitelabel.logo alt=env.whitelabel.name
     else
       img src="/images/logo-white.png"

--- a/config/environment.js
+++ b/config/environment.js
@@ -171,7 +171,9 @@ module.exports = function(environment) {
       integrateJIRA: { feature: "Integrate JIRA", module: "Report", product: "Appknox" },
       changePassword: { feature: "Change Password", module: "Setup", product: "Appknox" }
     },
-    whitelabel: {}
+    whitelabel: {
+      theme: 'dark'
+    }
   };
 
   if (environment === 'development') {
@@ -275,9 +277,10 @@ module.exports = function(environment) {
   }
 
   if (environment === 'whitelabel') {
-    ENV.isEnterprise = true;
+    ENV.isEnterprise = process.env.ENTERPRISE;
     ENV.whitelabel.name = process.env.WHITELABEL_NAME;
     ENV.whitelabel.logo = process.env.WHITELABEL_LOGO;
+    ENV.whitelabel.theme = process.env.WHITELABEL_THEME; // 'light' or 'dark'
     ENV.host = process.env.IRENE_API_HOST || 'https://api.appknox.com';
     ENV.socketPath = process.env.IRENE_API_SOCKET_PATH || 'https://socket.appknox.com';
   }


### PR DESCRIPTION
##### Whitelabel build:
Make sure env has `WHITELABEL_NAME`, `IRENE_API_HOST` & `IRENE_API_SOCKET_PATH`; and optional values `WHITELABEL_LOGO` & `WHITELABEL_THEME`
(The dark theme is active by default. Set `WHITELABEL_THEME=light` if white theme is required.)

```
$ ember build --environment=whitelabel
```
----
##### Light theme screenshots:

_Sidebar:_
<img width="200" alt="sidebar" src="https://user-images.githubusercontent.com/1054350/36330332-3a92f6dc-138f-11e8-8027-e9ecf83ca13c.png">
_Login page:_
<img width="200" alt="Login" src="https://user-images.githubusercontent.com/1054350/36330464-b3b587be-138f-11e8-9148-0e1593e9ae49.jpg">
