### PR TITLE
Show dynamic scan note

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -82,6 +82,7 @@ export default {
   "dynamicScan": "Dynamic Scan",
   "dynamicScanStart": "Start Dynamic Scan",
   "dynamicScanStop": "Stop Dynamic Scan",
+  "dynamicScanText": "Please refresh the page if the scan doesn't start in 1-2 mins",
   "dynamicShutDown": "Shutdown Device",
   "email": "Email",
   "emailOrUsername": "Email / Username",

--- a/app/locales/ja/translations.js
+++ b/app/locales/ja/translations.js
@@ -82,6 +82,7 @@ export default {
   "dynamicScan": "動的診断",
   "dynamicScanStart": "動的診断を開始",
   "dynamicScanStop": "動的診断を停止",
+  "dynamicScanText": "Please refresh the page if the scan doesn't start in 1-2 mins",
   "dynamicShutDown": "動的診断を終了",
   "email": "Eメール",
   "emailOrUsername": "Eメール/ユーザ名",

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -146,6 +146,11 @@ const File = DS.Model.extend(BaseModelMixin, {
     return ![ENUMS.DYNAMIC_STATUS.READY, ENUMS.DYNAMIC_STATUS.NONE].includes(status);
   }).property('dynamicStatus'),
 
+  startingScanStatus: (function() {
+    const status = this.get('dynamicStatus');
+    return ![ENUMS.DYNAMIC_STATUS.READY, ENUMS.DYNAMIC_STATUS.NONE, ENUMS.DYNAMIC_STATUS.SHUTTING_DOWN].includes(status);
+  }).property('dynamicStatus'),
+
   statusText: (function() {
     const tDeviceBooting = this.get("tDeviceBooting");
     const tDeviceDownloading = this.get("tDeviceDownloading");

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -2153,6 +2153,10 @@ $attachment-icon-width: 4em
   text-align: center
 
 .button-on-vnc
+  .note-text
+    position: absolute
+    max-width: 170px
+    font-size: 12px
   .vnc-box
     position: relative
     top: -400px

--- a/app/templates/components/dynamic-scan.emblem
+++ b/app/templates/components/dynamic-scan.emblem
@@ -29,6 +29,11 @@
       .fa-font-size-small
         = fa-icon "fa-stop"
       |  &nbsp; #{t "stop"}
+  if vncViewer
+    if file.startingScanStatus
+      div.note-text
+        = t "dynamicScanText"
+
 
 if notVNCViewer
   if file.project.isAPIScanEnabled

--- a/app/templates/components/vnc-viewer.emblem
+++ b/app/templates/components/vnc-viewer.emblem
@@ -25,4 +25,4 @@ if isPoppedOut
         = vncPopText
 
   .button-on-vnc
-    = dynamic-scan file=file notVNCViewer=false dynamicScanText=(t 'startDynamicScan')
+    = dynamic-scan file=file vncViewer=true notVNCViewer=false dynamicScanText=(t 'startDynamicScan')


### PR DESCRIPTION
shows a message below the device to refresh the page if the scan doesn't start. This message will be shows once someone starts the scan(Booting) until the scan is started(Starting)

![image](https://user-images.githubusercontent.com/10586875/40766954-bc915170-64ce-11e8-9401-2c3692c6e30e.png)
