### PR TITLE
Device preference enhancements

### DIFF
--- a/app/components/project-preferences.js
+++ b/app/components/project-preferences.js
@@ -15,7 +15,7 @@ const ProjectPreferencesComponent = Ember.Component.extend({
   tAnyVersion: t("anyVersion"),
 
   devicePreference: (function() {
-    return this.get("store").queryRecord('device-preference', {id: this.get("project.activeProfileId")});
+    return this.get("store").queryRecord('device-preference', {id: this.get("profileId")});
   }).property(),
 
   devices: (function() {
@@ -35,7 +35,7 @@ const ProjectPreferencesComponent = Ember.Component.extend({
   }).property("deviceTypes", "devicePreference.deviceType"),
 
   availableDevices: Ember.computed.filter('devices', function(device) {
-    return device.get("platform") === this.get("project.platform");
+    return device.get("platform") === this.get("platform");
   }),
 
   filteredDevices: Ember.computed("availableDevices", "selectedDeviceType", function() {
@@ -80,7 +80,7 @@ const ProjectPreferencesComponent = Ember.Component.extend({
       const selectVersion = this.get("selectVersion");
       const selectedDeviceType = this.get("selectedDeviceType");
 
-      const profileId = this.get("project.activeProfileId");
+      const profileId = this.get("profileId");
       const devicePreferences = [ENV.endpoints.profiles, profileId, ENV.endpoints.devicePreferences].join('/');
       const data = {
         device_type: selectedDeviceType,
@@ -97,6 +97,8 @@ const ProjectPreferencesComponent = Ember.Component.extend({
           setTimeout(() => {
             this.set("isSuccessful", false);
           }, 2000);
+          this.set("devicePreference.deviceType", selectedDeviceType);
+          this.set("devicePreference.platformVersion", selectVersion);
         }
       }, () => {
         if(!this.isDestroyed) {

--- a/app/components/project-preferences.js
+++ b/app/components/project-preferences.js
@@ -7,14 +7,11 @@ const ProjectPreferencesComponent = Ember.Component.extend({
 
   project: null,
   selectVersion: "0",
-  isSavingPreference: false,
   i18n: Ember.inject.service(),
   ajax: Ember.inject.service(),
   notify: Ember.inject.service('notification-messages-service'),
   deviceTypes: ENUMS.DEVICE_TYPE.CHOICES,
 
-  tDeviceSelected: t("deviceSelected"),
-  tPleaseTryAgain: t("pleaseTryAgain"),
   tAnyVersion: t("anyVersion"),
 
   devicePreference: (function() {
@@ -71,22 +68,16 @@ const ProjectPreferencesComponent = Ember.Component.extend({
     selectDeviceType() {
       this.set("selectedDeviceType", parseInt(this.$('#project-device-preference').val()));
       this.set("selectVersion", "0");
-      this.set("isChangingDevice", true);
       this.send("versionSelected");
-      this.set("isChangingDevice", false);
     },
 
     selectVersion() {
       this.set("selectVersion", this.$('#project-version-preference').val());
-      this.set("isChangingVersion", true);
       this.send("versionSelected");
-      this.set("isChangingVersion", false);
     },
 
     versionSelected() {
       const selectVersion = this.get("selectVersion");
-      const tDeviceSelected = this.get("tDeviceSelected");
-      const tPleaseTryAgain = this.get("tPleaseTryAgain");
       const selectedDeviceType = this.get("selectedDeviceType");
 
       const profileId = this.get("project.activeProfileId");
@@ -95,30 +86,26 @@ const ProjectPreferencesComponent = Ember.Component.extend({
         device_type: selectedDeviceType,
         platform_version: selectVersion
       };
+      this.set("showStatus", true);
       this.set("isSavingPreference", true);
       this.get("ajax").put(devicePreferences, {data})
       .then(() => {
-        this.get("notify").success(tDeviceSelected);
         if(!this.isDestroyed) {
           this.set("isSavingPreference", false);
-          this.set("projectPreferenceModal", false);
-          this.set("devicePreference.deviceType", selectedDeviceType);
-          this.set("devicePreference.platformVersion", selectVersion);
+          this.set("isNotSuccessful", false);
+          this.set("isSuccessful", true);
+          setTimeout(() => {
+            this.set("isSuccessful", false);
+          }, 2000);
         }
       }, () => {
         if(!this.isDestroyed) {
           this.set("isSavingPreference", false);
-          this.get("notify").error(tPleaseTryAgain);
+          this.set("isNotSuccessful", true);
+          this.set("devicePreference.deviceType", this.get("devicePreference.deviceType"));
+          this.set("devicePreference.platformVersion", this.get("devicePreference.platformVersion"));
         }
       });
-    },
-
-    openProjectPreferenceModal() {
-      this.set("projectPreferenceModal", true);
-    },
-
-    closeProjectPreferenceModal() {
-      this.set("projectPreferenceModal", false);
     }
   }
 });

--- a/app/components/project-preferences.js
+++ b/app/components/project-preferences.js
@@ -71,12 +71,16 @@ const ProjectPreferencesComponent = Ember.Component.extend({
     selectDeviceType() {
       this.set("selectedDeviceType", parseInt(this.$('#project-device-preference').val()));
       this.set("selectVersion", "0");
+      this.set("isChangingDevice", true);
       this.send("versionSelected");
+      this.set("isChangingDevice", false);
     },
 
     selectVersion() {
       this.set("selectVersion", this.$('#project-version-preference').val());
+      this.set("isChangingVersion", true);
       this.send("versionSelected");
+      this.set("isChangingVersion", false);
     },
 
     versionSelected() {

--- a/app/helpers/device-type.js
+++ b/app/helpers/device-type.js
@@ -7,13 +7,13 @@ const deviceType = function(params) {
   const currentDevice = params[0];
 
   if (currentDevice === ENUMS.DEVICE_TYPE.NO_PREFERENCE) {
-    return "noPreference";
+    return "anyDevice";
   } else if (currentDevice === ENUMS.DEVICE_TYPE.PHONE_REQUIRED) {
     return "phone";
   } else if (currentDevice === ENUMS.DEVICE_TYPE.TABLET_REQUIRED) {
     return "tablet";
   } else {
-    return "noPreference";
+    return "anyDevice";
   }
 };
 

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -20,6 +20,8 @@ export default {
   "alreadyHaveAccount": "Already have an account?",
   "amountPaid": "AMOUNT PAID",
   "analysisSettings": "Analysis Settings",
+  "anyDevice": "Any Device",
+  "anyVersion": "Any Version",
   "api": "API",
   "apiScan": "API Scan",
   "apiURLFilter": "API URL Filter",

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -308,6 +308,7 @@ export default {
   "showUntestedAnalysis": "SHOW/HIDE Untested Analysis",
   "signin": "Sign In",
   "sortBy": "Sort By",
+  "somethingWentWrong": "Something went wrong, please try again",
   "staging": "Staging",
   "start": "Start",
   "startDynamicScan": "Start Dynamic Scan",

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -274,7 +274,6 @@ export default {
   "resetPassword": "Reset your password",
   "repoIntegrated": "Repo successfully integrated",
   "repoNotIntegrated": "Something went wrong when trying to update this repo",
-  "reportCustomization": "Report Customization",
   "revokeGithub": "Revoke Github",
   "revokeJira": "Revoke Jira",
   "risk": "The risk of",

--- a/app/locales/ja/translations.js
+++ b/app/locales/ja/translations.js
@@ -274,7 +274,6 @@ export default {
   "resetPassword": "パスワードのリセット",
   "repoIntegrated": "リポジトリの連携に成功しました",
   "repoNotIntegrated": "リポジトリの更新時に問題が発生しました",
-  "reportCustomization": "Report Customization",
   "revokeGithub": "Githubを取り消す",
   "revokeJira": "JIRAを取り消す",
   "risk": "リスク",

--- a/app/locales/ja/translations.js
+++ b/app/locales/ja/translations.js
@@ -20,6 +20,8 @@ export default {
   "alreadyHaveAccount": "すでにアカウントをお持ちですか？",
   "amountPaid": "支払い金額",
   "analysisSettings": "Analysis Settings",
+  "anyDevice": "Any Device",
+  "anyVersion": "Any Version",
   "api": "API",
   "apiScan": "API診断",
   "apiURLFilter": "API URLフィルタ",

--- a/app/locales/ja/translations.js
+++ b/app/locales/ja/translations.js
@@ -308,6 +308,7 @@ export default {
   "showUntestedAnalysis": "SHOW/HIDE Untested Analysis",
   "signin": "サインイン",
   "sortBy": "並び替え",
+  "somethingWentWrong": "Something went wrong, please try again",
   "staging": "ステージング",
   "start": "開始",
   "startDynamicScan": "Start Dynamic Scan",

--- a/app/models/device-preference.js
+++ b/app/models/device-preference.js
@@ -8,16 +8,22 @@ export default DS.Model.extend({
   deviceType: DS.attr('number'),
   platformVersion: DS.attr('string'),
 
-  tNoPreference: t("noPreference"),
+  tAnyVersion: t("anyVersion"),
 
   versionText: (function() {
     const platformVersion = this.get("platformVersion");
-    const tNoPreference = this.get("tNoPreference");
+    const tAnyVersion = this.get("tAnyVersion");
     if (platformVersion === "0") {
-      return tNoPreference;
+      this.set("isAnyDevice", true);
+      return tAnyVersion;
     } else {
       return platformVersion;
     }
+  }).property("platformVersion"),
+
+  isAnyVersion: (function() {
+    const platformVersion = this.get("platformVersion");
+    return platformVersion !== "0";
   }).property("platformVersion")
 
 });

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -2419,3 +2419,7 @@ $attachment-icon-width: 4em
   margin-top: -30px
   i.fa
     font-size: 26px
+
+.project-preference
+  select
+    width: 150px

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -2439,3 +2439,6 @@ $attachment-icon-width: 4em
   margin-bottom: 30px
   .columns .column
     height: auto!important
+
+.request-status
+  min-height: 45px

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -530,25 +530,6 @@ button, .button
 .remove, .copy-password
   cursor: pointer
 
-.warning-band
-  width: 600px
-  margin: auto
-  margin-top: 10px
-  .columns
-    .column
-      display: flex
-      align-items: center
-      justify-content: center
-      height: 70px
-      &:first-child
-        background-color: #F5D76E
-      &:nth-child(2)
-        border-width: 2px 2px 2px 0px
-        border-style: solid
-        border-color: lighten($default, 50%)
-      i
-        font-size: 30px
-
 .api-scanning
   .warning-band
     padding: 0px 10px

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -199,6 +199,9 @@ body
 input
   display: block
 
+button:hover, button:active, button:focus
+  transition: all 0.4s!important
+
 .top-nav
   width: 100%
   margin-top: -10px
@@ -2421,6 +2424,7 @@ $attachment-icon-width: 4em
     font-size: 26px
 
 .project-preference, .project-preference-component
+  padding-bottom: 0px!important
   select
     width: 170px
   .fa-font-size
@@ -2441,4 +2445,8 @@ $attachment-icon-width: 4em
     height: auto!important
 
 .request-status
+  margin-top: -10px
+  padding: 0px 10px
   min-height: 45px
+  position: relative
+  top: 12px

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -2422,4 +2422,12 @@ $attachment-icon-width: 4em
 
 .project-preference
   select
-    width: 150px
+    width: 170px
+  .fa-font-size
+    margin-top: 5px
+    i
+      margin-top: 2px
+  .fa-check
+    color: $green
+  .fa-times
+    color: $red     

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -540,7 +540,7 @@ button, .button
       &:nth-child(2)
         border-width: 2px 2px 2px 0px
         border-style: solid
-        border-color: lighten($default, 50%)
+        border-color: lighten($default, 40%)
   .fa
     &-exclamation-triangle
       margin-top: 20px
@@ -2420,7 +2420,7 @@ $attachment-icon-width: 4em
   i.fa
     font-size: 26px
 
-.project-preference
+.project-preference, .project-preference-component
   select
     width: 170px
   .fa-font-size
@@ -2430,4 +2430,12 @@ $attachment-icon-width: 4em
   .fa-check
     color: $green
   .fa-times
-    color: $red     
+    color: $red
+
+.project-preference-component
+  margin-top: 10px
+  border: 2px solid lighten($grey, 40%)
+  padding: 10px
+  margin-bottom: 30px
+  .columns .column
+    height: auto!important

--- a/app/templates/components/dynamic-scan.emblem
+++ b/app/templates/components/dynamic-scan.emblem
@@ -58,6 +58,8 @@ if notVNCViewer
       .api-scanning
         h6
           = t "modalCard.runAPIScan.description"
+        .project-preference-component
+          = project-preferences project=file.project   
         form.margin-top20
           p.control
           .columns
@@ -78,6 +80,8 @@ if notVNCViewer
               = fa-icon 'info-circle'
             .column
               = t "modalCard.apiScan.dynamicScanText"
+        .project-preference-component
+          = project-preferences project=file.project
         form.margin-top30
           p.control
           .columns

--- a/app/templates/components/dynamic-scan.emblem
+++ b/app/templates/components/dynamic-scan.emblem
@@ -59,7 +59,7 @@ if notVNCViewer
         h6
           = t "modalCard.runAPIScan.description"
         .project-preference-component
-          = project-preferences project=file.project   
+          = project-preferences profileId=file.profile.id platform=file.project.platform
         form.margin-top20
           p.control
           .columns
@@ -81,7 +81,7 @@ if notVNCViewer
             .column
               = t "modalCard.apiScan.dynamicScanText"
         .project-preference-component
-          = project-preferences project=file.project
+          = project-preferences profileId=file.profile.id platform=file.project.platform
         form.margin-top30
           p.control
           .columns

--- a/app/templates/components/project-preferences.emblem
+++ b/app/templates/components/project-preferences.emblem
@@ -11,7 +11,7 @@ h6.margin-top
     = t "deviceType"
 .columns
   .column.is-one-third
-    select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference"
+    select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference" disabled=isChangingDevice
       option selected="true" value=devicePreference.deviceType
         | #{ t (device-type devicePreference.deviceType)}
       each filteredDeviceTypes as |deviceType|
@@ -22,7 +22,7 @@ h6.margin-top
     = t "osVersion"
 .columns
   .column.is-one-third
-    select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference"
+    select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference" disabled=isChangingVersion
       option selected="true" value=devicePreference.platformVersion
         | #{devicePreference.versionText}
       if devicePreference.isAnyVersion

--- a/app/templates/components/project-preferences.emblem
+++ b/app/templates/components/project-preferences.emblem
@@ -5,61 +5,29 @@
 
 h6.margin-top
   = t "otherTemplates.selectPreferredDevice"
-table.device-table
-  tr
-    td
-      = t "selectedDevice"
-    td
-      | #{ t (device-type devicePreference.deviceType)}
-  tr
-    td
-      = t "selectedVersion"
-    td
-      | #{devicePreference.versionText}
 
 .columns
-  .column.margin-top
-    button.is-primary click="openProjectPreferenceModal"
-     = t "changeDevice"
-
-
-= modal-card isActive=projectPreferenceModal title=(t "modalCard.devicePreference.title")
-  .card-body.warning-modal
-    .card-wrapper
-    form
-      .columns
-        .column
-          = t "deviceType"
-      .columns
-        .column.is-one-third
-          select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference"
-            option value=0
-              = t "noPreference"
-            each deviceTypes as |deviceType|
-              option value=deviceType.value
-                | #{ t (device-type deviceType.value)}
-      .columns
-        .column
-          = t "osVersion"
-      .columns
-        .column.is-one-third
-          select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference"
-            option value="0"
-              = t "noPreference"
-            each uniqueDevices as |device|
-              option value=device.platformVersion
-                = device.platformVersion
-
-      .columns
-        .column
-          button.margin-top20.is-primary.mp-select-device click="versionSelected" disabled=isSavingPreference
-            if isSavingPreference
-              .fa-font-size
-                i.fa class="fa-spinner fa-spin"
-              | &nbsp;
-            = t "modalCard.devicePreference.selectDevice"
-      small
-        = fa-icon "lightbulb-o"
-        span.margin-left5
-          | #{t "note"}:
-          | &nbsp;#{t "modalCard.devicePreference.note"}
+  .column
+    = t "deviceType"
+.columns
+  .column.is-one-third
+    select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference"
+      option selected="true" value=devicePreference.deviceType
+        | #{ t (device-type devicePreference.deviceType)}
+      each filteredDeviceTypes as |deviceType|
+        option value=deviceType.value
+          | #{ t (device-type deviceType.value)}
+.columns
+  .column
+    = t "osVersion"
+.columns
+  .column.is-one-third
+    select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference"
+      option selected="true" value=devicePreference.platformVersion
+        | #{devicePreference.versionText}
+      if devicePreference.isAnyVersion
+        option value="0"
+          = t "anyVersion"
+      each filteredUniqueDevices as |device|
+        option value=device.platformVersion
+          = device.platformVersion

--- a/app/templates/components/project-preferences.emblem
+++ b/app/templates/components/project-preferences.emblem
@@ -34,15 +34,15 @@ h6.margin-top
           = device.platformVersion
 
 .columns
-  .column
+  .column.request-status
     if showStatus
       .fa-font-size
         if isSavingPreference
           i.fa class="fa-spinner fa-spin"
-          | &nbsp; Please Wait
+          | &nbsp; #{t "pleaseWait"}
         if isSuccessful
           i.fa class="fa-check"
-          | &nbsp; Successfully saved the preference
+          | &nbsp; #{t "savedPreferences"}
         if isNotSuccessful
           i.fa class="fa-times"
-          | &nbsp; Something went wrong, please try again
+          | &nbsp; #{t "somethingWentWrong"}

--- a/app/templates/components/project-preferences.emblem
+++ b/app/templates/components/project-preferences.emblem
@@ -10,7 +10,7 @@ h6.margin-top
   .column
     = t "deviceType"
 .columns
-  .column.is-one-sixth
+  .column
     select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference" disabled=isSavingPreference
       option selected="true" value=devicePreference.deviceType
         | #{ t (device-type devicePreference.deviceType)}
@@ -22,7 +22,7 @@ h6.margin-top
  .column
     = t "osVersion"
 .columns
-  .column.is-one-third
+  .column
     select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference" disabled=isSavingPreference
       option selected="true" value=devicePreference.platformVersion
         | #{devicePreference.versionText}

--- a/app/templates/components/project-preferences.emblem
+++ b/app/templates/components/project-preferences.emblem
@@ -10,19 +10,20 @@ h6.margin-top
   .column
     = t "deviceType"
 .columns
-  .column.is-one-third
-    select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference" disabled=isChangingDevice
+  .column.is-one-sixth
+    select.input.mp-device-preference{action 'selectDeviceType' on='change'} id="project-device-preference" disabled=isSavingPreference
       option selected="true" value=devicePreference.deviceType
         | #{ t (device-type devicePreference.deviceType)}
       each filteredDeviceTypes as |deviceType|
         option value=deviceType.value
           | #{ t (device-type deviceType.value)}
+
 .columns
-  .column
+ .column
     = t "osVersion"
 .columns
   .column.is-one-third
-    select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference" disabled=isChangingVersion
+    select.input.mp-version-preference{action 'selectVersion' on='change'} id="project-version-preference" disabled=isSavingPreference
       option selected="true" value=devicePreference.platformVersion
         | #{devicePreference.versionText}
       if devicePreference.isAnyVersion
@@ -31,3 +32,17 @@ h6.margin-top
       each filteredUniqueDevices as |device|
         option value=device.platformVersion
           = device.platformVersion
+
+.columns
+  .column
+    if showStatus
+      .fa-font-size
+        if isSavingPreference
+          i.fa class="fa-spinner fa-spin"
+          | &nbsp; Please Wait
+        if isSuccessful
+          i.fa class="fa-check"
+          | &nbsp; Successfully saved the preference
+        if isNotSuccessful
+          i.fa class="fa-times"
+          | &nbsp; Something went wrong, please try again

--- a/app/templates/components/project-settings.emblem
+++ b/app/templates/components/project-settings.emblem
@@ -19,7 +19,7 @@
 
 if isGeneralSettings
   .box-container.project-preference
-    = project-preferences project=project
+    = project-preferences profileId=project.activeProfileId platform=project.platform
   .box-container
     = api-filter profileId=project.activeProfileId
   .box-container

--- a/app/templates/components/project-settings.emblem
+++ b/app/templates/components/project-settings.emblem
@@ -18,7 +18,7 @@
         = t "analysisSettings"
 
 if isGeneralSettings
-  .box-container
+  .box-container.project-preference
     = project-preferences project=project
   .box-container
     = api-filter profileId=project.activeProfileId

--- a/config/environment.js
+++ b/config/environment.js
@@ -277,7 +277,7 @@ module.exports = function(environment) {
     ENV.rollbar = {
       enabled: false
     };
-    ENV['host'] = "https://api.appknox.io";
+    ENV['host'] = "https://api.appknox.com";
   }
 
   if (environment === 'test') {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -35,6 +35,7 @@ export default function() {
   this.get('/profiles/:id/github_integration');
   this.get('/profiles/:id/jira_integration');
   this.get('/profiles/:id/vulnerability_preferences', 'vulnerability-preference');
+  this.get('/available_devices/', 'available-device');
   this.get('/subscriptions/', 'subscription');
   this.get('/stats/:id', 'stat');
   this.get('/personaltokens', 'personaltoken');

--- a/mirage/factories/available-device.js
+++ b/mirage/factories/available-device.js
@@ -1,0 +1,7 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  isTablet: faker.random.boolean,
+  platformVersion: "2.3",
+  platform: 1
+});

--- a/mirage/factories/device.js
+++ b/mirage/factories/device.js
@@ -1,5 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
-import { faker } from 'ember-cli-mirage';
+import { Factory, faker } from 'ember-cli-mirage';
 import ENUMS from 'irene/enums';
 
 export default Factory.extend({

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -18,9 +18,7 @@ export default Base.extend({
   showIgnoredAnalysis: faker.random.boolean,
   activeProfileId: 2,
 
-  platform(){
-    return faker.random.arrayElement(ENUMS.PLATFORM.VALUES);
-  },
+  platform: 1,
 
   deviceType() {
     return faker.random.arrayElement(ENUMS.DEVICE_TYPE.VALUES);

--- a/mirage/models/available-device.js
+++ b/mirage/models/available-device.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -16,6 +16,7 @@ export default function(server) {
     submissionCount = getRandomInt(3,3),
     personalTokenCount = getRandomInt(3,3),
     invitationCount = getRandomInt(1,1),
+    availableDeviceCount = getRandomInt(3,3),
     teamCount = 3,
     githubCount = 1,
     jiraCount = 1,
@@ -36,6 +37,7 @@ export default function(server) {
   server.createList('github-integration', githubCount);
   server.createList('jira-integration', jiraCount);
   server.createList('vulnerability-preference', vulnerabilityPreferenceCount);
+  server.createList('available-device', availableDeviceCount);
   projectCount =  getRandomInt(4, 5);
   for (var teamId = 1; teamId <= teamCount; teamId++) {
     team = server.create('team', {users: users});

--- a/tests/integration/components/dynamic-scan-test.js
+++ b/tests/integration/components/dynamic-scan-test.js
@@ -15,6 +15,7 @@ moduleForComponent('dynamic-scan', 'Integration | Component | dynamic scan', {
     'component:fa-icon',
     'component:modal-card',
     'component:api-filter',
+    'component:project-preferences',
     'service:notification-messages-service',
     'service:session',
     'locale:en/translations',

--- a/tests/integration/components/project-preferences-test.js
+++ b/tests/integration/components/project-preferences-test.js
@@ -52,33 +52,7 @@ test('tapping button fires an external action', function(assert) {
           }
         }
       ];
-    }
-  };
-  component.set('store', store);
-  Ember.run(function() {
-    component.set("project", {activeProfileId:1});
-    component.send('versionSelected');
-    assert.deepEqual(component.get("devices"), [{
-      "attributes": {
-        "name": "test",
-        "platform": 1
-      },
-      "id": 1,
-      "type": "device"
-      }
-    ], 'devices');
-    assert.equal(component.get("isSavingPreference"), true, 'Saving Preference');
-    component.send('openProjectPreferenceModal');
-    assert.equal(component.get("projectPreferenceModal"), true, 'Open Modal');
-    component.send('closeProjectPreferenceModal');
-    assert.equal(component.get("projectPreferenceModal"), false, 'Close Modal');
-    component.set("selectedDeviceType", ENUMS.DEVICE_TYPE.NO_PREFERENCE);
-  });
-});
-
-test('tapping button fires an external action', function(assert) {
-  var component = this.subject();
-  var store = {
+    },
     queryRecord: function() {
       return [
         {
@@ -94,7 +68,17 @@ test('tapping button fires an external action', function(assert) {
   };
   component.set('store', store);
   Ember.run(function() {
-    component.set("project", {activeProfileId:1});
+    component.set("profileId", 1);
+    component.send('versionSelected');
+    assert.deepEqual(component.get("devices"), [{
+      "attributes": {
+        "name": "test",
+        "platform": 1
+      },
+      "id": 1,
+      "type": "device"
+      }
+    ], 'devices');
     assert.deepEqual(component.get("devicePreference"), [{
       "attributes": {
         "deviceType": 1,
@@ -104,5 +88,7 @@ test('tapping button fires an external action', function(assert) {
       "type": "device-preference"
       }
     ], 'device preference');
+    assert.equal(component.get("isSavingPreference"), true, 'Saving Preference');
+    component.set("selectedDeviceType", ENUMS.DEVICE_TYPE.NO_PREFERENCE);
   });
 });

--- a/tests/unit/helpers/device-type-test.js
+++ b/tests/unit/helpers/device-type-test.js
@@ -5,8 +5,8 @@ import { deviceType } from 'irene/helpers/device-type';
 module('Unit | Helper | device type');
 
 test('it works', function(assert) {
-  assert.equal(deviceType([42]), "noPreference", "No Preference");
-  assert.equal(deviceType([ENUMS.DEVICE_TYPE.NO_PREFERENCE]), "noPreference", "No Preference");
+  assert.equal(deviceType([42]), "anyDevice", "No Preference");
+  assert.equal(deviceType([ENUMS.DEVICE_TYPE.NO_PREFERENCE]), "anyDevice", "No Preference");
   assert.equal(deviceType([ENUMS.DEVICE_TYPE.PHONE_REQUIRED]), "phone", "Phone");
   assert.equal(deviceType([ENUMS.DEVICE_TYPE.TABLET_REQUIRED]), "tablet", "Tablet");
 });

--- a/tests/unit/models/device-preference-test.js
+++ b/tests/unit/models/device-preference-test.js
@@ -24,6 +24,6 @@ test('it exists', function(assert) {
     devicePreference.set('platformVersion', "1");
     assert.equal(devicePreference.get('versionText'), "1", "Version Text");
     devicePreference.set('platformVersion', "0");
-    assert.equal(devicePreference.get('versionText.string'), "No Preference", "Version Text");
+    assert.equal(devicePreference.get('versionText.string'), "Any Version", "Version Text");
   });
 });


### PR DESCRIPTION
- [x] Removed modal for Device Preference
- [x] Renamed text from No Preference to Any Device & Any Version for better understanding
- [x] Modified `device-preference` component for reusability 
- [x] Support for device selection during API Scan & Dynamic Scan

Settings Page

![image](https://user-images.githubusercontent.com/10586875/42431419-f31688e8-8362-11e8-80d4-afadeb15953c.png)

API Scan Modal

![image](https://user-images.githubusercontent.com/10586875/42431458-2607c21c-8363-11e8-80b3-39d766d12755.png)

Dynamic Scan Modal

![image](https://user-images.githubusercontent.com/10586875/42431470-362c7c0a-8363-11e8-9cf6-40a0a9b872d7.png)

![image](https://user-images.githubusercontent.com/10586875/42439953-e9741944-8381-11e8-8567-66a7bec49f9e.png)
