### PR TITLE
Added option to set dynamic done in security dashboard

### DIFF
--- a/app/components/file-actions.js
+++ b/app/components/file-actions.js
@@ -23,8 +23,7 @@ export default Component.extend({
   }),
 
   fileDetails: computed(function() {
-    const fileid = this.get("file.fileid");
-    return this.get("store").findRecord("security/file", fileid);
+    return this.get('file');
   }),
 
   ireneFilePath: computed(function() {

--- a/app/components/file-actions.js
+++ b/app/components/file-actions.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
+import { computed, observer } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import ENUMS from 'irene/enums';
 import { task } from 'ember-concurrency';
@@ -47,6 +47,30 @@ export default Component.extend({
   }),
 
   setApiScanStatusErrored: on('setApiScanStatus:errored', function(_, error) {
+    let errMsg = this.get('tPleaseTryAgain');
+    if (error.errors && error.errors.length) {
+      errMsg = error.errors[0].detail || errMsg;
+    } else if(error.message) {
+      errMsg = error.message;
+    }
+    this.get("notify").error(errMsg);
+  }),
+
+  /* Watch for isDynamicDone input */
+  watchDynamicDone: observer('fileDetails.isDynamicDone', function(){
+    this.get('setDynamicDone').perform();
+  }),
+
+  setDynamicDone: task(function * () {
+    const file = yield this.get("fileDetails");
+    yield file.save();
+  }).evented(),
+
+  setDynamicDoneSucceeded: on('setDynamicDone:succeeded', function() {
+    this.get('notify').success('Dynamic scan status updated');
+  }),
+
+  setDynamicDoneErrored: on('setDynamicDone:errored', function(_, error) {
     let errMsg = this.get('tPleaseTryAgain');
     if (error.errors && error.errors.length) {
       errMsg = error.errors[0].detail || errMsg;

--- a/app/models/security/file.js
+++ b/app/models/security/file.js
@@ -14,7 +14,8 @@ export default DS.Model.extend({
 
   isApiDone: computed('apiScanStatus', function() {
     const apiScanStatus = this.get("apiScanStatus");
-    if(apiScanStatus === ENUMS.SCAN_STATUS.COMPLETED) return true
-  })
+    if(apiScanStatus === ENUMS.SCAN_STATUS.COMPLETED) return true;
+  }),
+  isDynamicDone: DS.attr('boolean'),
 
 });

--- a/app/routes/authenticated/security/file.js
+++ b/app/routes/authenticated/security/file.js
@@ -3,4 +3,8 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   title: `File Details${config.platform}`,
+  async model(params){
+    await this.get('store').findAll('Vulnerability');
+    return this.get('store').findRecord('security/file', params.fileid);
+  }
 });

--- a/app/templates/components/file-actions.emblem
+++ b/app/templates/components/file-actions.emblem
@@ -38,8 +38,12 @@
                   | Scan Status
             .columns
               .column.margin-top
-                = input id="api-scan-status" class="checkbox" checked=fileDetails.isApiDone type="checkbox" click=(perform setApiScanStatus) class="display-inline"
-                | &nbsp; Is API done
+                div
+                  = input id="api-scan-status" class="checkbox" checked=fileDetails.isApiDone type="checkbox" click=(perform setApiScanStatus) class="display-inline"
+                  | &nbsp; Is API done
+                div
+                  = input type="checkbox" class="checkbox" name="dynamic-scan-status" checked=fileDetails.isDynamicDone
+                  | &nbsp; Is Dynamic done
 
 
       .columns

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,0 +1,3 @@
+module.exports = {
+  useBabelInstrumenter: true,
+};

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -49,7 +49,7 @@ test('it exists', function(assert) {
     assert.equal(user.get('hasExpiryDate'), false, "No Expiry Date");
 
     assert.equal(user.get('expiryText'), "subscriptionExpired", "Expiry Text");
-    user.set('expiryDate', new Date("25 March 2019"));
+    user.set('expiryDate', new Date("25 March 2050"));
     assert.equal(user.get('expiryText'), "subscriptionWillExpire", "Expiry Text");
 
     assert.equal(user.get('namespaceItems'), undefined, "Namespace Items");

--- a/tests/unit/routes/authenticated/security/file-test.js
+++ b/tests/unit/routes/authenticated/security/file-test.js
@@ -1,11 +1,12 @@
+import { run } from '@ember/runloop';
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:authenticated/security/file', 'Unit | Route | authenticated/security/file', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
 });
 
 test('it exists', function(assert) {
   let route = this.subject();
-  assert.ok(route);
+  run(function() {
+    assert.ok(route);
+  });
 });


### PR DESCRIPTION
- Added option to set set dynamic done in security dashboard:
	<img width="736" alt="Screenshot 2019-03-22 at 5 56 09 PM" src="https://user-images.githubusercontent.com/1054350/54822822-d5c46200-4ccb-11e9-93e7-df888422f627.png">
- Added `config/coverage.js` with babel support config, which fixes existing problems with async/await not being able to test
