### PR TITLE
Cleanup analysis risk status states

### DIFF
--- a/app/components/analysis-details.js
+++ b/app/components/analysis-details.js
@@ -38,28 +38,22 @@ const AnalysisDetailsComponent = Component.extend({
     return filteredRisks[0].value;
   }),
 
-  riskClass: computed("analysis.computedRisk", function() {
-    const risk = this.get("analysis.computedRisk");
-    switch (risk) {
-      case ENUMS.RISK.NONE:
-        return "is-success";
-      case ENUMS.RISK.LOW:
-        return "is-info";
-      case ENUMS.RISK.MEDIUM:
-        return "is-warning";
-      case ENUMS.RISK.HIGH:
-        return "is-danger";
-      case ENUMS.RISK.CRITICAL:
-        return "is-critical";
+  statusClass: computed("analysis.{status,computedRisk}", function() {
+    const status = this.get("analysis.status");
+    if (status === ENUMS.ANALYSIS.WAITING) {
+      return "is-waiting"
     }
-  }),
-
-  progressClass: computed("analysis.computedRisk", function() {
-    const risk = this.get("analysis.computedRisk");
-    switch (risk) {
-      case ENUMS.RISK.UNKNOWN:
-        return "is-progress";
+    if (status === ENUMS.ANALYSIS.RUNNING) {
+      return "is-progress"
     }
+    if (status === ENUMS.ANALYSIS.ERROR) {
+      return "is-errored"
+    }
+    const risk = this.get("analysis.computedRisk");
+    if (risk === ENUMS.RISK.UNKNOWN) {
+      return "is-untested"
+    }
+    return "is-completed";
   }),
 
   editAnalysisURL(type) {

--- a/app/components/risk-tag.js
+++ b/app/components/risk-tag.js
@@ -2,52 +2,17 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import ENUMS from 'irene/enums';
-import { translationMacro as t } from 'ember-i18n';
+import { analysisRiskStatus } from 'irene/helpers/analysis-risk-status';
 
 export default Component.extend({
   analysis: null,
   i18n: service(),
 
-  tScanning: t("scanning"),
-  tUntested: t("untested"),
-  tRequested: t("requested"),
-
   isNonPassedRiskOverridden: computed('analysis.{risk,overriddenRisk}', function() {
     return this.get('analysis.overriddenRisk') != null && this.get('analysis.risk') != ENUMS.RISK.NONE;
   }),
 
-  scanningText: computed(
-    "analysis.vulnerability.types",
-    "analysis.file.{dynamicStatus,manual,apiScanProgress}", function() {
-    const tScanning = this.get("tScanning");
-    const tUntested = this.get("tUntested");
-    const tRequested = this.get("tRequested");
-    const types = this.get("analysis.vulnerability.types");
-    if (types === undefined) { return []; }
-    switch (types[0]) {
-      case ENUMS.VULNERABILITY_TYPE.STATIC: {
-        return tScanning;
-      }
-      case ENUMS.VULNERABILITY_TYPE.DYNAMIC: {
-        const dynamicStatus = this.get('analysis.file.dynamicStatus');
-        if(dynamicStatus !== ENUMS.DYNAMIC_STATUS.NONE) {
-          return tScanning;
-        }
-        return tUntested;
-      }
-      case ENUMS.VULNERABILITY_TYPE.MANUAL: {
-        if(this.get("analysis.file.manual")) {
-          return tRequested;
-        }
-        return tUntested;
-      }
-      case ENUMS.VULNERABILITY_TYPE.API: {
-        const apiScanProgress = this.get('analysis.file.apiScanProgress');
-        if(apiScanProgress >= 1) {
-          return tScanning;
-        }
-        return tUntested;
-      }
-    }
-  })
+  analysisRiskStatus: computed('analysis.{computedRisk,status}', function() {
+    return analysisRiskStatus([this.get('analysis.computedRisk'), this.get('analysis.status')]);
+  }),
 });

--- a/app/helpers/analysis-risk-status.js
+++ b/app/helpers/analysis-risk-status.js
@@ -1,0 +1,91 @@
+import { helper } from '@ember/component/helper';
+import ENUMS from 'irene/enums';
+
+export function analysisRiskStatus(params) {
+  let risk = null;
+  let status = null;
+
+  try {
+    risk = parseInt(params[0])
+  } catch(_) {
+    // null risk
+  }
+
+  try {
+    status = parseInt(params[1])
+  } catch(_) {
+    // null status
+  }
+
+  const classes = {
+    status: {
+      [ENUMS.ANALYSIS.ERROR]: 'is-errored',
+      [ENUMS.ANALYSIS.WAITING]: 'is-waiting',
+      [ENUMS.ANALYSIS.RUNNING]: 'is-progress',
+    },
+    risk: {
+      [ENUMS.RISK.UNKNOWN]: 'is-default',
+      [ENUMS.RISK.NONE]: 'is-success',
+      [ENUMS.RISK.LOW]: 'is-info',
+      [ENUMS.RISK.MEDIUM]: 'is-warning',
+      [ENUMS.RISK.HIGH]: 'is-danger',
+      [ENUMS.RISK.CRITICAL]: 'is-critical',
+    }
+  }
+
+  const icons = {
+    status: {
+      [ENUMS.ANALYSIS.ERROR]: 'fa-warning',
+      [ENUMS.ANALYSIS.WAITING]: 'fa-minus-circle',
+      [ENUMS.ANALYSIS.RUNNING]: 'fa-spinner fa-spin',
+    },
+    risk: {
+      [ENUMS.RISK.UNKNOWN]: 'fa-close',
+      [ENUMS.RISK.NONE]: 'fa-check',
+      [ENUMS.RISK.LOW]: 'fa-warning',
+      [ENUMS.RISK.MEDIUM]: 'fa-warning',
+      [ENUMS.RISK.HIGH]: 'fa-warning',
+      [ENUMS.RISK.CRITICAL]: 'fa-warning',
+    }
+  }
+
+  const labels = {
+    status: {
+      [ENUMS.ANALYSIS.ERROR]: 'Errored',
+      [ENUMS.ANALYSIS.WAITING]: 'Not started',
+      [ENUMS.ANALYSIS.RUNNING]: 'Scanning',
+    },
+    risk: {
+      [ENUMS.RISK.UNKNOWN]: 'Untested',
+      [ENUMS.RISK.NONE]: 'Passed',
+      [ENUMS.RISK.LOW]: 'Low',
+      [ENUMS.RISK.MEDIUM]: 'Medium',
+      [ENUMS.RISK.HIGH]: 'High',
+      [ENUMS.RISK.CRITICAL]: 'Critical',
+    }
+  }
+
+  if ((status || status == 0) && status !== ENUMS.ANALYSIS.COMPLETED) {
+    return {
+      cssclass: classes.status[status] || '',
+      icon: icons.status[status] || '',
+      label: labels.status[status] || '',
+    };
+  }
+
+  if (risk !== null) {
+    return {
+      cssclass: classes.risk[risk] || '',
+      icon: icons.risk[risk] || '',
+      label: labels.risk[risk] || '',
+    };
+  }
+
+  return {
+    cssclass: '',
+    icon: '',
+    label: '',
+  }
+}
+
+export default helper(analysisRiskStatus);

--- a/app/helpers/risk-label-class.js
+++ b/app/helpers/risk-label-class.js
@@ -1,24 +1,9 @@
 import { helper } from '@ember/component/helper';
-import ENUMS from 'irene/enums';
+import { analysisRiskStatus } from 'irene/helpers/analysis-risk-status';
 
 export function riskLabelClass(params) {
-  let risk = params[0];
-  if (risk === null || risk === '') {
-    return ''
-  }
-  if(typeof risk === "object") {
-    risk = risk.value;
-  }
-  risk = parseInt(risk);
-  const labels = {
-    [ENUMS.RISK.UNKNOWN]: 'is-progress',
-    [ENUMS.RISK.NONE]: 'is-success',
-    [ENUMS.RISK.LOW]: 'is-info',
-    [ENUMS.RISK.MEDIUM]: 'is-warning',
-    [ENUMS.RISK.HIGH]: 'is-danger',
-    [ENUMS.RISK.CRITICAL]: 'is-critical',
-  }
-  return labels[risk] || '';
+  const riskStatus = analysisRiskStatus(params);
+  return riskStatus.cssclass;
 }
 
 export default helper(riskLabelClass);

--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -1274,19 +1274,30 @@ b.bold
   border-radius: 5px 0px 0px 5px
   border-width: 0px!important
   padding: 4px 10px
+  background-color: #f6f8fa
+  border-color: #f6f8fa
   .severity-tags
-    width: 90px
+    width: 9.8em
   h6
     font-size: 16px
   .columns
     margin-top: 0px
-  &:nth-child(odd)
-    background-color: #f6f8fa
 
-.message .message-header.is-progress
-  border-color: rgb(255, 224, 221)
-  border-width: 1px 1px 1px 5px
-  border-style: solid
+.message .message-header
+  &.is-progress
+    border-color: rgb(255, 224, 221)
+    border-width: 1px 1px 1px 5px
+    border-style: solid
+  &.is-untested
+    border-color: #f5f5f5
+    border-width: 1px 1px 1px 5px
+    border-style: solid
+    background-color: #f5f5f5
+  &.is-errored
+    border-color: rgb(255, 224, 221)
+    border-width: 1px 1px 1px 5px
+    border-style: solid
+    background-color: lighten(rgb(255, 224, 221), 2%)
 
 .vuln-header
   border-width: 1px 1px 1px 5px
@@ -1688,9 +1699,17 @@ button.delete-button
     list-style: disc
     margin-left: 20px
 
-.tag.delete-tag
-  background-color: $red
-  color: #fff
+.tag
+  border: 1px solid transparent
+  &.delete-tag
+    background-color: $red
+    color: #fff
+  &.is-errored
+    color: $red
+    border-color: rgba($red, 0.4)
+  &.is-waiting
+    color: rgba($color-table, 0.9)
+    border-color: rgba($color-table, 0.2)
 
 .colored-box
   margin: auto

--- a/app/templates/components/analysis-details.emblem
+++ b/app/templates/components/analysis-details.emblem
@@ -1,6 +1,6 @@
 .columns
   .column
-    .message-header.vuln-header.hideOrShow click="toggleVulnerability" class=mpClassSelector:mp-plus:mp-minus class=progressClass
+    .message-header.vuln-header.hideOrShow click="toggleVulnerability" class=mpClassSelector:mp-plus:mp-minus class=statusClass
       .columns
         = risk-tag analysis=analysis columnSize="is-one-sixth"
         .column

--- a/app/templates/components/risk-tag.emblem
+++ b/app/templates/components/risk-tag.emblem
@@ -1,19 +1,9 @@
-if analysis
-  .column.severity-tags class="tag {{risk-label-class analysis.computedRisk}}" class=columnSize
-    i.fa.risk-icons class=analysis.computedRiskIconClass
-    if analysis.isScanning
-      .uppercase-text
-        | &nbsp;{{scanningText}}
-    else
-      .uppercase-text
-        | &nbsp; #{ t (risk-text analysis.computedRisk)}
-      if isNonPassedRiskOverridden
-        img src="/images/user-edited.svg" class="user-edited-icon"
-        = attach-tooltip placement="top"
-          | #{ t "overriddenRisk"},&nbsp;
-          | #{ t "orginalRisk"}: #{t (risk-text analysis.risk)}
-else
-  .column.severity-tags.tag.is-progress class=columnSize
-    i.fa.risk-icons.fa-spinner.fa-spin
-    .uppercase-text
-      | &nbsp; #{t "untested"}
+.column.severity-tags class="tag {{analysisRiskStatus.cssclass}}" class=columnSize
+  i.fa.risk-icons class="{{analysisRiskStatus.icon}}"
+  .uppercase-text.padding-l-h
+    | {{analysisRiskStatus.label}}
+  if isNonPassedRiskOverridden
+    img src="/images/user-edited.svg" class="user-edited-icon"
+    = attach-tooltip placement="top"
+      | #{ t "overriddenRisk"},&nbsp;
+      | #{ t "orginalRisk"}: #{t (risk-text analysis.risk)}

--- a/tests/integration/components/analysis-details-test.js
+++ b/tests/integration/components/analysis-details-test.js
@@ -50,7 +50,7 @@ test('tapping button fires an external action', function(assert) {
   this.render();
   run(function() {
     component.set("risks", ENUMS.RISK.CHOICES.slice(0, -1));
-    component.set('analysis', {computedRisk:ENUMS.RISK.NONE});
+    component.set('analysis', {computedRisk: ENUMS.RISK.NONE, status: ENUMS.ANALYSIS.COMPLETED});
     assert.deepEqual(component.get("filteredRisks"),
       [
         {"key": "NONE","value": 0},
@@ -60,17 +60,6 @@ test('tapping button fires an external action', function(assert) {
         {"key": "CRITICAL","value": 4}
       ], 'Filtered Risks');
     assert.equal(component.get("markedRisk"), 0, 'Marked Risk');
-    assert.equal(component.get('riskClass'), "is-success", "Success");
-    component.set('analysis', {computedRisk:ENUMS.RISK.LOW});
-    assert.equal(component.get('riskClass'), "is-info", "Info");
-    component.set('analysis', {computedRisk:ENUMS.RISK.MEDIUM});
-    assert.equal(component.get('riskClass'), "is-warning", "Warning");
-    component.set('analysis', {computedRisk:ENUMS.RISK.HIGH});
-    assert.equal(component.get('riskClass'), "is-danger", "Danger");
-    component.set('analysis', {computedRisk:ENUMS.RISK.CRITICAL});
-    assert.equal(component.get('riskClass'), "is-critical", "Critical");
-    component.set('analysis', {computedRisk:ENUMS.RISK.UNKNOWN});
-    assert.equal(component.get('progressClass'), "is-progress", "Progress");
     component.send('toggleVulnerability');
     assert.equal(component.get('showVulnerability'),true, "Show Vulnerability");
 
@@ -98,4 +87,29 @@ test('tapping button fires an external action', function(assert) {
     component.set("analysis", {vulnerability: {types: [4]}, file: {isApiDone:true}});
     assert.deepEqual(component.get("tags")[0], {"status": true,"text": "api"}, 'Risk Type');
   });
+});
+
+test('statusClass is computed correctly', function(assert) {
+  var component = this.subject();
+  this.render();
+
+  run(function() {
+    component.set('analysis', {status: ENUMS.ANALYSIS.COMPLETED, computedRisk: ENUMS.RISK.NONE});
+    assert.equal(component.get('statusClass'), 'is-completed');
+
+    component.set('analysis', {status: ENUMS.ANALYSIS.WAITING});
+    assert.equal(component.get('statusClass'), 'is-waiting');
+
+    component.set('analysis', {status: ENUMS.ANALYSIS.RUNNING});
+    assert.equal(component.get('statusClass'), 'is-progress');
+
+    component.set('analysis', {status: ENUMS.ANALYSIS.ERROR});
+    assert.equal(component.get('statusClass'), 'is-errored');
+
+    component.set('analysis', {status: ENUMS.ANALYSIS.COMPLETED, computedRisk: ENUMS.RISK.UNKNOWN});
+    assert.equal(component.get('statusClass'), 'is-untested');
+
+    component.set('analysis', {status: ENUMS.ANALYSIS.RUNNING, computedRisk: ENUMS.RISK.UNKNOWN});
+    assert.equal(component.get('statusClass'), 'is-progress');
+  })
 });

--- a/tests/integration/components/risk-tag-test.js
+++ b/tests/integration/components/risk-tag-test.js
@@ -3,6 +3,7 @@ import tHelper from 'ember-i18n/helper';
 import localeConfig from 'ember-i18n/config/en';
 import { test, moduleForComponent } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import ENUMS from 'irene/enums';
 
 moduleForComponent('risk-tag', 'Integration | Component | risk tag', {
   unit: true,
@@ -24,58 +25,19 @@ moduleForComponent('risk-tag', 'Integration | Component | risk tag', {
   }
 });
 
-test('tapping button fires an external action', function(assert) {
-
+test('analysisRiskStatus is computed correctly', function(assert) {
   var component = this.subject();
-
   run(function() {
-    assert.equal(component.get("scanningText"), "", "Scanning Text");
-    component.set("analysis", {vulnerability: {types: [1]}});
-    assert.equal(component.get("scanningText").string, "Scanning", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [2]
-      },
-      file: {
-        dynamicStatus: 0
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Untested", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [2]
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Scanning", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [3]
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Untested", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [3]
-      },
-      file: {
-        manual: true
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Requested", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [4]
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Untested", "Scanning Text");
-    component.set("analysis", {
-      vulnerability: {
-        types: [4]
-      },
-      file: {
-        apiScanProgress: 1
-      }
-    });
-    assert.equal(component.get("scanningText").string, "Scanning", "Scanning Text");
+    component.set('analysis', {computedRisk: 3, status: ENUMS.ANALYSIS.COMPLETED});
+    const analysisRiskStatus1 = component.get('analysisRiskStatus');
+    assert.equal(analysisRiskStatus1.cssclass, 'is-danger');
+    assert.equal(analysisRiskStatus1.icon, 'fa-warning');
+    assert.equal(analysisRiskStatus1.label, 'High');
+
+    component.set('analysis', {computedRisk: -1, status: ENUMS.ANALYSIS.WAITING});
+    const analysisRiskStatus2 = component.get('analysisRiskStatus');
+    assert.equal(analysisRiskStatus2.cssclass, 'is-waiting');
+    assert.equal(analysisRiskStatus2.icon, 'fa-minus-circle');
+    assert.equal(analysisRiskStatus2.label, 'Not started');
   });
 });

--- a/tests/unit/helpers/analysis-risk-status-test.js
+++ b/tests/unit/helpers/analysis-risk-status-test.js
@@ -1,0 +1,188 @@
+import { module, test } from 'qunit';
+import ENUMS from 'irene/enums';
+import { analysisRiskStatus } from 'irene/helpers/analysis-risk-status';
+
+
+module('Unit | Helper | analysis risk status');
+
+test('it return risk status for completed analysis', function(assert) {
+  const status = ENUMS.ANALYSIS.COMPLETED;
+
+  let unknown = analysisRiskStatus([ENUMS.RISK.UNKNOWN, status]);
+  assert.equal(unknown.cssclass, 'is-default');
+  assert.equal(unknown.icon, 'fa-close');
+  assert.equal(unknown.label, 'Untested');
+
+  let passed = analysisRiskStatus([ENUMS.RISK.NONE, status]);
+  assert.equal(passed.cssclass, 'is-success');
+  assert.equal(passed.icon, 'fa-check');
+  assert.equal(passed.label, 'Passed');
+
+  let low = analysisRiskStatus([ENUMS.RISK.LOW, status]);
+  assert.equal(low.cssclass, 'is-info');
+  assert.equal(low.icon, 'fa-warning');
+  assert.equal(low.label, 'Low');
+
+  let medium = analysisRiskStatus([ENUMS.RISK.MEDIUM, status]);
+  assert.equal(medium.cssclass, 'is-warning');
+  assert.equal(medium.icon, 'fa-warning');
+  assert.equal(medium.label, 'Medium');
+
+  let high = analysisRiskStatus([ENUMS.RISK.HIGH, status]);
+  assert.equal(high.cssclass, 'is-danger');
+  assert.equal(high.icon, 'fa-warning');
+  assert.equal(high.label, 'High');
+
+  let critical = analysisRiskStatus([ENUMS.RISK.CRITICAL, status]);
+  assert.equal(critical.cssclass, 'is-critical');
+  assert.equal(critical.icon, 'fa-warning');
+  assert.equal(critical.label, 'Critical');
+});
+
+test('it return error status for errored analysis', function(assert) {
+  let riskStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, ENUMS.ANALYSIS.ERROR]);
+  assert.equal(riskStatus.cssclass, 'is-errored');
+  assert.equal(riskStatus.icon, 'fa-warning');
+  assert.equal(riskStatus.label, 'Errored');
+});
+
+test('it return not-started status for waiting analysis', function(assert) {
+  let riskStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, ENUMS.ANALYSIS.WAITING]);
+  assert.equal(riskStatus.cssclass, 'is-waiting');
+  assert.equal(riskStatus.icon, 'fa-minus-circle');
+  assert.equal(riskStatus.label, 'Not started');
+});
+
+test('it return scanning status for running analysis', function(assert) {
+  let riskStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, ENUMS.ANALYSIS.RUNNING]);
+  assert.equal(riskStatus.cssclass, 'is-progress');
+  assert.equal(riskStatus.icon, 'fa-spinner fa-spin');
+  assert.equal(riskStatus.label, 'Scanning');
+});
+
+test('it return risk status if status param is empty', function(assert) {
+  let riskStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN]);
+  assert.equal(riskStatus.cssclass, 'is-default');
+  assert.equal(riskStatus.icon, 'fa-close');
+  assert.equal(riskStatus.label, 'Untested');
+
+  let undefinedStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, undefined]);
+  assert.equal(undefinedStatus.cssclass, 'is-default');
+  assert.equal(undefinedStatus.icon, 'fa-close');
+  assert.equal(undefinedStatus.label, 'Untested');
+
+  let emptyStrStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, '']);
+  assert.equal(emptyStrStatus.cssclass, 'is-default');
+  assert.equal(emptyStrStatus.icon, 'fa-close');
+  assert.equal(emptyStrStatus.label, 'Untested');
+
+  let nullStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, null]);
+  assert.equal(nullStatus.cssclass, 'is-default');
+  assert.equal(nullStatus.icon, 'fa-close');
+  assert.equal(nullStatus.label, 'Untested');
+});
+
+test('it return empty if risk param is empty & completed status', function(assert) {
+  const status = ENUMS.ANALYSIS.COMPLETED;
+
+  let undefinedRisk = analysisRiskStatus([undefined, status]);
+  assert.equal(undefinedRisk.cssclass, '');
+  assert.equal(undefinedRisk.icon, '');
+  assert.equal(undefinedRisk.label, '');
+
+  let emptyStrRisk = analysisRiskStatus(['', status]);
+  assert.equal(emptyStrRisk.cssclass, '');
+  assert.equal(emptyStrRisk.icon, '');
+  assert.equal(emptyStrRisk.label, '');
+
+  let nullRisk = analysisRiskStatus([null, status]);
+  assert.equal(nullRisk.cssclass, '');
+  assert.equal(nullRisk.icon, '');
+  assert.equal(nullRisk.label, '');
+});
+
+test('it return status if risk param is empty & non-completed status', function(assert) {
+  const status = ENUMS.ANALYSIS.ERROR;
+
+  let undefinedRisk = analysisRiskStatus([undefined, status]);
+  assert.equal(undefinedRisk.cssclass, 'is-errored');
+  assert.equal(undefinedRisk.icon, 'fa-warning');
+  assert.equal(undefinedRisk.label, 'Errored');
+
+  let emptyStrRisk = analysisRiskStatus(['', status]);
+  assert.equal(emptyStrRisk.cssclass, 'is-errored');
+  assert.equal(emptyStrRisk.icon, 'fa-warning');
+  assert.equal(emptyStrRisk.label, 'Errored');
+
+  let nullRisk = analysisRiskStatus([null, status]);
+  assert.equal(nullRisk.cssclass, 'is-errored');
+  assert.equal(nullRisk.icon, 'fa-warning');
+  assert.equal(nullRisk.label, 'Errored');
+});
+
+test('it return empty values for invalid risk & invalid status', function(assert) {
+  let invalidRiskStatus = analysisRiskStatus([5, 4]);
+  assert.equal(invalidRiskStatus.cssclass, '');
+  assert.equal(invalidRiskStatus.icon, '');
+  assert.equal(invalidRiskStatus.label, '');
+
+  let invalidStatus2 = analysisRiskStatus([-2, -2]);
+  assert.equal(invalidStatus2.cssclass, '');
+  assert.equal(invalidStatus2.icon, '');
+  assert.equal(invalidStatus2.label, '');
+});
+
+test('it return empty values for valid risk & invalid status', function(assert) {
+  let invalidStatus = analysisRiskStatus([ENUMS.RISK.UNKNOWN, -5]);
+  assert.equal(invalidStatus.cssclass, '');
+  assert.equal(invalidStatus.icon, '');
+  assert.equal(invalidStatus.label, '');
+});
+
+test('it return empty values for invalid risk & completed status', function(assert) {
+  let invalidRiskCompletedStatus = analysisRiskStatus([-2, ENUMS.ANALYSIS.COMPLETED]);
+  assert.equal(invalidRiskCompletedStatus.cssclass, '');
+  assert.equal(invalidRiskCompletedStatus.icon, '');
+  assert.equal(invalidRiskCompletedStatus.label, '');
+});
+
+test('it return empty values for invalid risk & non-completed status', function(assert) {
+  let invalidRiskErroredStatus = analysisRiskStatus([-2, ENUMS.ANALYSIS.ERROR]);
+  assert.equal(invalidRiskErroredStatus.cssclass, 'is-errored');
+  assert.equal(invalidRiskErroredStatus.icon, 'fa-warning');
+  assert.equal(invalidRiskErroredStatus.label, 'Errored');
+});
+
+test('it works for non integer inputs', function(assert) {
+  let boolInput1 = analysisRiskStatus([true]);
+  assert.equal(boolInput1.cssclass, '');
+  assert.equal(boolInput1.icon, '');
+  assert.equal(boolInput1.label, '');
+
+  let boolInput2 = analysisRiskStatus([true, false]);
+  assert.equal(boolInput2.cssclass, '');
+  assert.equal(boolInput2.icon, '');
+  assert.equal(boolInput2.label, '');
+
+  let boolInput3 = analysisRiskStatus([true, ENUMS.ANALYSIS.COMPLETED]);
+  assert.equal(boolInput3.cssclass, '');
+  assert.equal(boolInput3.icon, '');
+  assert.equal(boolInput3.label, '');
+
+  let objInput1 = analysisRiskStatus([{}]);
+  assert.equal(objInput1.cssclass, '');
+  assert.equal(objInput1.icon, '');
+  assert.equal(objInput1.label, '');
+
+  let objInput2 = analysisRiskStatus([{}, ENUMS.ANALYSIS.COMPLETED]);
+  assert.equal(objInput2.cssclass, '');
+  assert.equal(objInput2.icon, '');
+  assert.equal(objInput2.label, '');
+});
+
+test('it works for empty input', function(assert) {
+  let emptyInput = analysisRiskStatus([]);
+  assert.equal(emptyInput.cssclass, '');
+  assert.equal(emptyInput.icon, '');
+  assert.equal(emptyInput.label, '');
+});

--- a/tests/unit/helpers/risk-label-class-test.js
+++ b/tests/unit/helpers/risk-label-class-test.js
@@ -6,7 +6,7 @@ module('Unit | Helper | risk label class');
 
 test('it return correct class for valid risks', function(assert) {
   let unknown = riskLabelClass([-1]);
-  assert.equal(unknown, 'is-progress');
+  assert.equal(unknown, 'is-default');
 
   let passed = riskLabelClass([0]);
   assert.equal(passed, 'is-success');


### PR DESCRIPTION
### Sample states:

If analysis status is NOT COMPLETED, render `status`:

#### Not started
<img width="795" alt="Screenshot 2019-04-11 at 2 55 15 AM" src="https://user-images.githubusercontent.com/1054350/55914746-91125380-5c05-11e9-838c-e09db4f272e6.png">

#### Running
<img width="796" alt="Screenshot 2019-04-11 at 2 56 05 AM" src="https://user-images.githubusercontent.com/1054350/55914758-98d1f800-5c05-11e9-92d1-0c0bdf1e00a1.png">

#### Errored
<img width="794" alt="Screenshot 2019-04-11 at 2 55 43 AM" src="https://user-images.githubusercontent.com/1054350/55914777-a4252380-5c05-11e9-8847-53632fccf717.png">

---

If analysis status is COMPLETED, render `computedRisk` value:

#### Risk
<img width="799" alt="Screenshot 2019-04-11 at 2 48 42 AM" src="https://user-images.githubusercontent.com/1054350/55914720-82c43780-5c05-11e9-8104-34e3da284afb.png">

#### Untested
<img width="797" alt="Screenshot 2019-04-11 at 2 56 44 AM" src="https://user-images.githubusercontent.com/1054350/55914786-a8514100-5c05-11e9-98bc-43bd856f87cd.png">
