### PR TITLE
[HOTFIX] Whitelabel Instance & Favicon Fixes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,6 @@
     <script src="{{rootURL}}runtimeconfig.js"></script>
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/irene.css">
-    <link rel="shortcut icon" href="{{rootURL}}images/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro:400,700|Open+Sans:400,600,700" rel="stylesheet">
     {{content-for "head-footer"}}
   </head>

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,6 +11,7 @@ export default class ApplicationRoute extends Route {
 
   afterModel() {
     this.headData.title = "Appknox";
+    this.headData.favicon = this.whitelabel.favicon;
   }
 
   setupController(controller) {

--- a/app/services/whitelabel.js
+++ b/app/services/whitelabel.js
@@ -16,7 +16,8 @@ export default class WhitelabelService extends Service {
   }
 
   default_name = "Appknox";
-  defautl_theme = this.THEMES.DARK;
+  default_theme = this.THEMES.DARK;
+  default_favicon = ENV.favicon;
 
 
   /**
@@ -27,7 +28,7 @@ export default class WhitelabelService extends Service {
     if(this.isEnabled()) {
       return ENV.whitelabel.theme
     }
-    return this.defautl_theme;
+    return this.default_theme;
   }
 
   /**
@@ -39,5 +40,16 @@ export default class WhitelabelService extends Service {
       return ENV.whitelabel.name;
     }
     return this.default_name;
+  }
+
+  /**
+   * @property {String} favicon
+   * Whitelabel favicon will be returned or fallback default to `favicon.ico`.
+   */
+  get favicon() {
+    if(this.isEnabled() && ENV.whitelabel.favicon)  {
+      return ENV.whitelabel.favicon;
+    }
+    return this.default_favicon;
   }
 }

--- a/app/templates/components/api-filter.emblem
+++ b/app/templates/components/api-filter.emblem
@@ -13,7 +13,7 @@
         | &nbsp;
       | + {{t "templates.addNewUrlFilter"}}
   small
-    | eg. api.appknox.com. Do not specify the scheme (http://...), port (:443/...) & path (.../users)
+    | {{t "templates.enterEndpoint"}}
 
 if apiScanOptions.hasApiUrlFilters
 

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,2 +1,3 @@
 <title>{{this.model.title}}</title>
 <meta name="og:title" property="og:title" content={{this.model.title}} />
+<link rel="shortcut icon" href="{{this.model.favicon}}">

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,6 +16,7 @@ const possibleENVS = [
   "WHITELABEL_NAME",
   "WHITELABEL_LOGO",
   "WHITELABEL_THEME",
+  "WHITELABEL_FAVICON",
 ];
 
 const ENVHandlerCONST = {
@@ -215,6 +216,7 @@ module.exports = function (environment) {
       },
     },
     rootURL: "/",
+    favicon: "/images/favicon.ico",
     locationType: "auto",
     modulePrefix: "irene",
     environment: environment,
@@ -564,6 +566,7 @@ module.exports = function (environment) {
     ENV.whitelabel.name = handler.getEnv('WHITELABEL_NAME');
     ENV.whitelabel.logo = handler.getEnv('WHITELABEL_LOGO');
     ENV.whitelabel.theme = handler.getEnv('WHITELABEL_THEME'); // 'light' or 'dark'
+    ENV.whitelabel.favicon = handler.getEnv('WHITELABEL_FAVICON');
   }
 
   if (environment === "development") {

--- a/staticserver/index.js
+++ b/staticserver/index.js
@@ -23,6 +23,7 @@ const ENVs = [
   "WHITELABEL_NAME",
   "WHITELABEL_LOGO",
   "WHITELABEL_THEME",
+  "WHITELABEL_FAVICON",
 ];
 
 const app = express();


### PR DESCRIPTION
Following Quick Fixes were implemented:
1. Hardcoded string of API scan modal box was replaced with the translated version
2. Fix Favicon for white-label instances, with a fall back to default Appknox favicon