### PR TITLE
Fixed spelling in JIRA integration error message

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -812,7 +812,7 @@
   "sync": "Sync More",
   "system": "System",
   "systemStatus": "System Status",
-  "tInValidCredentials": "Invalid credentails",
+  "tInValidCredentials": "Invalid credentials",
   "tablet": "Tablet",
   "team": "Team",
   "teamCreated": "Team Created Successfully",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -812,7 +812,7 @@
   "sync": "同期する",
   "system": "System",
   "systemStatus": "System Status",
-  "tInValidCredentials": "Invalid credentails",
+  "tInValidCredentials": "Invalid credentials",
   "tablet": "タブレット",
   "team": "チーム",
   "teamCreated": "チームが作成されました",


### PR DESCRIPTION
Fixed the spelling of credentials in the error message while integrating JIRA.