### PR TITLE
move docker builder image tag from 16.18.0-stretch to 16.18.0-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.0-stretch AS builder
+FROM node:16.18.0-bullseye AS builder
 
 LABEL maintainer "Appknox <engineering@appknox.com>"
 


### PR DESCRIPTION
REASON:  16.18.0-stretch does not exist anymore