### PR TITLE
Translation path fixes

### DIFF
--- a/app/components/notifications-page/messages/nf-am-newversn/index.hbs
+++ b/app/components/notifications-page/messages/nf-am-newversn/index.hbs
@@ -16,9 +16,11 @@
         @color='primary'
         @route='authenticated.app-monitoring'
         @underline='always'
-        @title='{{t "viewStoreMonitoring"}}'
+        @title='{{t "notificationModule.viewStoreMonitoring"}}'
       >
-        <:default>{{t 'viewStoreMonitoringResults'}}</:default>
+        <:default>{{t
+            'notificationModule.viewStoreMonitoringResults'
+          }}</:default>
       </AkLink>
     </div>
   </div>

--- a/app/components/notifications-page/messages/nf-apistcmpltd1/index.hbs
+++ b/app/components/notifications-page/messages/nf-apistcmpltd1/index.hbs
@@ -19,7 +19,7 @@
 
   <div data-test-nf-apistcmpltd1-risk-count local-class='vulnerability-stats'>
     <AkTypography @variant='subtitle2' class='pb-2'>{{t
-        'currentRiskStatusFile'
+        'notificationModule.currentRiskStatusFile'
       }}</AkTypography>
     <ul local-class='severity-levels'>
       <li local-class='severity-level'>

--- a/app/components/notifications-page/messages/nf-dastcmpltd1/index.hbs
+++ b/app/components/notifications-page/messages/nf-dastcmpltd1/index.hbs
@@ -19,7 +19,7 @@
 
   <div data-test-nf-dastcmpltd1-risk-count local-class='vulnerability-stats'>
     <AkTypography @variant='subtitle2' class='pb-2'>{{t
-        'currentRiskStatusFile'
+        'notificationModule.currentRiskStatusFile'
       }}</AkTypography>
     <ul local-class='severity-levels'>
       <li local-class='severity-level'>

--- a/app/components/notifications-page/messages/nf-nsautoapprvd1/index.hbs
+++ b/app/components/notifications-page/messages/nf-nsautoapprvd1/index.hbs
@@ -1,6 +1,7 @@
 <div>
   {{t
     'notificationModule.messages.nf-nsautoapprvd1'
+    htmlSafe=true
     platform_display=@context.platform_display
     namespace_value=@context.namespace_value
   }}

--- a/app/components/notifications-page/messages/nf-nsautoapprvd2/index.hbs
+++ b/app/components/notifications-page/messages/nf-nsautoapprvd2/index.hbs
@@ -1,6 +1,7 @@
 <div>
   {{t
     'notificationModule.messages.nf-nsautoapprvd2'
+    htmlSafe=true
     platform_display=@context.platform_display
     namespace_value=@context.namespace_value
     requester_username=@context.requester_username

--- a/app/components/notifications-page/messages/nf-sastcmpltd1/index.hbs
+++ b/app/components/notifications-page/messages/nf-sastcmpltd1/index.hbs
@@ -19,7 +19,7 @@
 
   <div data-test-nf-sastcmpltd1-risk-count local-class='vulnerability-stats'>
     <AkTypography @variant='subtitle2' class='pb-2'>{{t
-        'riskStatus'
+        'notificationModule.riskStatus'
       }}</AkTypography>
     <ul local-class='severity-levels'>
       <li local-class='severity-level'>

--- a/tests/integration/components/notifications-page/messages/nf-apistcmpltd1-test.js
+++ b/tests/integration/components/notifications-page/messages/nf-apistcmpltd1-test.js
@@ -61,9 +61,11 @@ module(
         .dom('[data-test-nf-apistcmpltd1-risk-count]')
         .exists()
         .containsText(
-          `${t('currentRiskStatusFile')} ${t('critical')} 1 ${t('high')} 2 ${t(
-            'medium'
-          )} 3 ${t('low')} 4 ${t('passed')} 5 ${t('untested')} 10`
+          `${t('notificationModule.currentRiskStatusFile')} ${t(
+            'critical'
+          )} 1 ${t('high')} 2 ${t('medium')} 3 ${t('low')} 4 ${t(
+            'passed'
+          )} 5 ${t('untested')} 10`
         );
 
       assert

--- a/tests/integration/components/notifications-page/messages/nf-dastcmpltd1-test.js
+++ b/tests/integration/components/notifications-page/messages/nf-dastcmpltd1-test.js
@@ -62,9 +62,11 @@ module(
         .dom('[data-test-nf-dastcmpltd1-risk-count]')
         .exists()
         .containsText(
-          `${t('currentRiskStatusFile')} ${t('critical')} 1 ${t('high')} 2 ${t(
-            'medium'
-          )} 3 ${t('low')} 4 ${t('passed')} 5 ${t('untested')} 10`
+          `${t('notificationModule.currentRiskStatusFile')} ${t(
+            'critical'
+          )} 1 ${t('high')} 2 ${t('medium')} 3 ${t('low')} 4 ${t(
+            'passed'
+          )} 5 ${t('untested')} 10`
         );
 
       assert

--- a/tests/integration/components/notifications-page/messages/nf-sastcmpltd1-test.js
+++ b/tests/integration/components/notifications-page/messages/nf-sastcmpltd1-test.js
@@ -62,9 +62,11 @@ module(
         .dom('[data-test-nf-sastcmpltd1-risk-count]')
         .exists()
         .containsText(
-          `${t('riskStatus')} ${t('critical')} 1 ${t('high')} 2 ${t(
-            'medium'
-          )} 3 ${t('low')} 4 ${t('passed')} 5 ${t('untested')} 10`
+          `${t('notificationModule.riskStatus')} ${t('critical')} 1 ${t(
+            'high'
+          )} 2 ${t('medium')} 3 ${t('low')} 4 ${t('passed')} 5 ${t(
+            'untested'
+          )} 10`
         );
 
       assert


### PR DESCRIPTION
In tests the intl module is used. Which was masking the text content from translations files. This probable would be a good idea for acceptance testing.