### PR TITLE
Move third party initialization to ember initialzer

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,11 +1,8 @@
 import ENUMS from 'irene/enums';
 import config from 'irene/config/environment';
-import installPendo from 'irene/utils/install-pendo';
 import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
-import installHotjar from 'irene/utils/install-hotjar';
-import customerSuccessBox from 'irene/utils/customer-success-box';
 import { registerDateLibrary } from 'ember-power-calendar';
 import DateUtils from 'irene/utils/power-calendar-dayjs';
 
@@ -20,9 +17,6 @@ if (config.isAppknox) {
   config.product = ENUMS.PRODUCT.DEVKNOX;
 }
 
-installPendo();
-installHotjar();
-customerSuccessBox();
 registerDateLibrary(DateUtils);
 
 export default class App extends Application {

--- a/app/initializers/irene.js
+++ b/app/initializers/irene.js
@@ -1,4 +1,7 @@
 import ENV from 'irene/config/environment';
+import installPendo from 'irene/utils/install-pendo';
+import installHotjar from 'irene/utils/install-hotjar';
+import customerSuccessBox from 'irene/utils/customer-success-box';
 
 class ENVHandler {
   constructor(envHandlerConst) {
@@ -138,6 +141,10 @@ const initialize = function (application) {
   ENV.emberRollbarClient = {
     enabled: handler.getValueForPlugin('IRENE_ENABLE_ROLLBAR'),
   };
+
+  installPendo();
+  installHotjar();
+  customerSuccessBox();
 
   // Inject ENV
   if (ENV.environment !== 'test') {


### PR DESCRIPTION
This is to handle get the proper env values from runtimeconfig.js and its loaded after the ember base code is executed.