### PR TITLE
Improve: the DAST device and VNC experience

### DIFF
--- a/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/index.ts
+++ b/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/index.ts
@@ -11,6 +11,7 @@ import type DS from 'ember-data';
 
 import styles from './index.scss';
 import ENUMS from 'irene/enums';
+import { getIOSManualDeviceVersionParams } from 'irene/utils/dynamic-scan-device';
 import { type PaginationProviderActionsArgs } from 'irene/components/ak-pagination-provider';
 import type { DsPreferenceContext } from 'irene/components/ds-preference-provider';
 import type FileModel from 'irene/models/file';
@@ -50,6 +51,7 @@ export interface FileDetailsDynamicScanDrawerDevicePrefTableSignature {
   Args: {
     dpContext: DsPreferenceContext;
     file: FileModel;
+    onSelectedManualDeviceAvailable(deviceIdentifier: string): void;
   };
 }
 
@@ -185,6 +187,8 @@ export default class FileDetailsDynamicScanDrawerDevicePrefTableComponent extend
 
     preference.dsManualDeviceIdentifier = device.deviceIdentifier;
 
+    this.args.onSelectedManualDeviceAvailable(device.deviceIdentifier);
+
     this.dpContext.updateDsManualDevicePref(preference);
   }
 
@@ -230,8 +234,25 @@ export default class FileDetailsDynamicScanDrawerDevicePrefTableComponent extend
 
         this.availableDevicesResponse = (await this.store.query(
           'available-manual-device',
-          { ...queryParams, platform_version_min: this.args.file.minOsVersion }
+          {
+            ...queryParams,
+            ...getIOSManualDeviceVersionParams(this.args.file),
+          }
         )) as AvailableManualDeviceQueryResponse;
+
+        const selectedDeviceIdentifier =
+          this.devicePreference?.dsManualDeviceIdentifier;
+
+        const selectedDeviceIsAvailableInResponse =
+          this.availableManualDevices.some(
+            (device) => device.deviceIdentifier === selectedDeviceIdentifier
+          );
+
+        if (selectedDeviceIdentifier && selectedDeviceIsAvailableInResponse) {
+          this.args.onSelectedManualDeviceAvailable(selectedDeviceIdentifier);
+        } else {
+          this.args.onSelectedManualDeviceAvailable('');
+        }
       } catch (error) {
         const err = error as AdapterError;
         const errorStatus = err.errors?.[0]?.status;

--- a/app/components/file-details/dynamic-scan/action/drawer/index.hbs
+++ b/app/components/file-details/dynamic-scan/action/drawer/index.hbs
@@ -56,6 +56,7 @@
           @file={{@file}}
           @isApiCaptureEnabled={{this.isApiCaptureEnabled}}
           @onApiCaptureChange={{this.handleApiCaptureChange}}
+          @onSelectedManualDeviceAvailable={{this.handleSelectedManualDeviceAvailable}}
         />
       {{/if}}
     </AkStack>

--- a/app/components/file-details/dynamic-scan/action/drawer/index.ts
+++ b/app/components/file-details/dynamic-scan/action/drawer/index.ts
@@ -8,6 +8,7 @@ import { isEmpty } from '@ember/utils';
 import ENV from 'irene/config/environment';
 import ENUMS from 'irene/enums';
 import parseError from 'irene/utils/parse-error';
+import { getIOSManualDeviceVersionParams } from 'irene/utils/dynamic-scan-device';
 
 import type IntlService from 'ember-intl/services/intl';
 import type Store from 'ember-data/store';
@@ -39,6 +40,7 @@ export default class FileDetailsDynamicScanActionDrawerComponent extends Compone
 
   @tracked isApiCaptureEnabled = false;
   @tracked availableManualDevices: AvailableManualDeviceModel[] = [];
+  @tracked selectedAvailableManualDeviceIdentifier: string | null = null;
 
   constructor(
     owner: unknown,
@@ -80,6 +82,13 @@ export default class FileDetailsDynamicScanActionDrawerComponent extends Compone
     );
   }
 
+  get selectedManualDeviceIsFromAvailableDeviceTable() {
+    return (
+      this.selectedAvailableManualDeviceIdentifier ===
+      this.dsManualDeviceIdentifier
+    );
+  }
+
   get enableStartDynamicScanBtn() {
     const { isAutomatedScan, dpContext } = this.args;
 
@@ -96,11 +105,17 @@ export default class FileDetailsDynamicScanActionDrawerComponent extends Compone
         dsManualDeviceSelection === anyDeviceSelection ||
         (specificDeviceSelection === dsManualDeviceSelection &&
           !isEmpty(this.dsManualDeviceIdentifier) &&
-          this.selectedManualDeviceIsInAvailableDeviceList)
+          (this.selectedManualDeviceIsInAvailableDeviceList ||
+            this.selectedManualDeviceIsFromAvailableDeviceTable))
       );
     }
 
     return true;
+  }
+
+  @action
+  handleSelectedManualDeviceAvailable(deviceIdentifier: string) {
+    this.selectedAvailableManualDeviceIdentifier = deviceIdentifier || null;
   }
 
   @action
@@ -122,10 +137,21 @@ export default class FileDetailsDynamicScanActionDrawerComponent extends Compone
       );
 
       const devices = await this.store.query('available-manual-device', {
-        platform_version_min: this.args.file.minOsVersion,
+        ...getIOSManualDeviceVersionParams(this.file),
       });
 
       this.availableManualDevices = devices.slice();
+
+      if (
+        this.selectedAvailableManualDeviceIdentifier &&
+        !this.availableManualDevices.some(
+          (device) =>
+            device.deviceIdentifier ===
+            this.selectedAvailableManualDeviceIdentifier
+        )
+      ) {
+        this.selectedAvailableManualDeviceIdentifier = null;
+      }
     } catch (error) {
       const err = error as AdapterError;
       const errorStatus = err.errors?.[0]?.status;

--- a/app/components/file-details/dynamic-scan/action/drawer/manual-dast/index.hbs
+++ b/app/components/file-details/dynamic-scan/action/drawer/manual-dast/index.hbs
@@ -76,6 +76,7 @@
       <FileDetails::DynamicScan::Action::Drawer::DevicePrefTable
         @file={{@file}}
         @dpContext={{@dpContext}}
+        @onSelectedManualDeviceAvailable={{@onSelectedManualDeviceAvailable}}
       />
     {{/if}}
   </AkStack>

--- a/app/components/file-details/dynamic-scan/action/drawer/manual-dast/index.ts
+++ b/app/components/file-details/dynamic-scan/action/drawer/manual-dast/index.ts
@@ -13,6 +13,7 @@ export interface FileDetailsDynamicScanDrawerManualDastSignature {
     dpContext: DsPreferenceContext;
     isApiCaptureEnabled: boolean;
     onApiCaptureChange(event: Event, checked?: boolean): void;
+    onSelectedManualDeviceAvailable(deviceIdentifier: string): void;
   };
 }
 

--- a/app/components/file-details/dynamic-scan/automated/index.ts
+++ b/app/components/file-details/dynamic-scan/automated/index.ts
@@ -13,6 +13,7 @@ import type DsAutomationPreferenceModel from 'irene/models/ds-automation-prefere
 import type OrganizationService from 'irene/services/organization';
 import type DynamicscanModel from 'irene/models/dynamicscan';
 import type LoggerService from 'irene/services/logger';
+import type EventBusService from 'irene/services/event-bus';
 
 export interface FileDetailsDastAutomatedSignature {
   Args: {
@@ -28,6 +29,7 @@ export default class FileDetailsDastAutomated extends Component<FileDetailsDastA
   @service declare organization: OrganizationService;
   @service('notifications') declare notify: NotificationService;
   @service declare logger: LoggerService;
+  @service declare eventBus: EventBusService;
 
   @tracked automationPreference: DsAutomationPreferenceModel | null = null;
   @tracked lastAutomatedDynamicScan: DynamicscanModel | null = null;
@@ -37,6 +39,12 @@ export default class FileDetailsDastAutomated extends Component<FileDetailsDastA
 
     this.getDsAutomationPreference.perform();
     this.getLastAutomatedDynamicScan.perform();
+
+    this.eventBus.on(
+      'ws:dynamicscan:update',
+      this,
+      this.handleDynamicScanUpdate
+    );
   }
 
   get file() {
@@ -82,7 +90,14 @@ export default class FileDetailsDastAutomated extends Component<FileDetailsDastA
     this.getLastAutomatedDynamicScan.perform();
   }
 
-  getLastAutomatedDynamicScan = task(async () => {
+  @action
+  handleDynamicScanUpdate(dynamicscan: DynamicscanModel) {
+    if (String(dynamicscan.file.get('id')) === String(this.file.id)) {
+      this.getLastAutomatedDynamicScan.perform();
+    }
+  }
+
+  getLastAutomatedDynamicScan = task({ restartable: true }, async () => {
     try {
       this.lastAutomatedDynamicScan =
         await this.file.getFileLastAutomatedDynamicScan();
@@ -90,6 +105,16 @@ export default class FileDetailsDastAutomated extends Component<FileDetailsDastA
       this.logger.error(parseError(error, this.intl.t('pleaseTryAgain')));
     }
   });
+
+  willDestroy(): void {
+    super.willDestroy();
+
+    this.eventBus.off(
+      'ws:dynamicscan:update',
+      this,
+      this.handleDynamicScanUpdate
+    );
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/file-details/dynamic-scan/manual/index.ts
+++ b/app/components/file-details/dynamic-scan/manual/index.ts
@@ -9,6 +9,7 @@ import type IntlService from 'ember-intl/services/intl';
 import type FileModel from 'irene/models/file';
 import type DynamicScanService from 'irene/services/dynamic-scan';
 import type DynamicscanModel from 'irene/models/dynamicscan';
+import type EventBusService from 'irene/services/event-bus';
 
 export interface FileDetailsDastManualSignature {
   Args: {
@@ -21,6 +22,7 @@ export default class FileDetailsDastManual extends Component<FileDetailsDastManu
   @service('dynamic-scan') declare dsService: DynamicScanService;
   @service declare intl: IntlService;
   @service('notifications') declare notify: NotificationService;
+  @service declare eventBus: EventBusService;
 
   @tracked lastManualDynamicScan: DynamicscanModel | null = null;
 
@@ -35,6 +37,12 @@ export default class FileDetailsDastManual extends Component<FileDetailsDastManu
     });
 
     this.getLastDynamicScans.perform();
+
+    this.eventBus.on(
+      'ws:dynamicscan:update',
+      this,
+      this.handleDynamicScanUpdate
+    );
   }
 
   get file() {
@@ -71,11 +79,28 @@ export default class FileDetailsDastManual extends Component<FileDetailsDastManu
     this.getLastDynamicScans.perform();
   }
 
-  getLastDynamicScans = task(async () => {
+  @action
+  handleDynamicScanUpdate(dynamicscan: DynamicscanModel) {
+    if (String(dynamicscan.file.get('id')) === String(this.file.id)) {
+      this.getLastDynamicScans.perform();
+    }
+  }
+
+  getLastDynamicScans = task({ restartable: true }, async () => {
     this.lastManualDynamicScan = await waitForPromise(
       this.file.getFileLastManualDynamicScan()
     );
   });
+
+  willDestroy(): void {
+    super.willDestroy();
+
+    this.eventBus.off(
+      'ws:dynamicscan:update',
+      this,
+      this.handleDynamicScanUpdate
+    );
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/novnc-rfb/index.hbs
+++ b/app/components/novnc-rfb/index.hbs
@@ -1,6 +1,7 @@
 <div
   data-test-NovncRfb-canvasContainer
   data-test-cy='NovncRfb-canvasContainer'
+  data-contain-canvas={{if @containCanvas 'true' 'false'}}
   local-class='novnc-rfb'
   {{did-insert this.onDidInsertElement}}
   {{will-destroy this.onWillDestroyElement}}

--- a/app/components/novnc-rfb/index.scss
+++ b/app/components/novnc-rfb/index.scss
@@ -6,4 +6,16 @@
     cursor: pointer !important;
     overflow: hidden;
   }
+
+  &[data-contain-canvas='true'] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    canvas {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+  }
 }

--- a/app/components/novnc-rfb/index.ts
+++ b/app/components/novnc-rfb/index.ts
@@ -7,43 +7,76 @@ import RFB from '@novnc/novnc/lib/rfb';
 export interface NovncRfbSignature {
   Args: {
     deviceFarmURL: string | null;
-    deviceFarmPassword: string;
+    deviceFarmPassword?: string | null;
     allowInteraction?: boolean;
+    containCanvas?: boolean;
   };
 }
 
 export default class NovncRfbComponent extends Component<NovncRfbSignature> {
   @tracked rfb: any = null;
+  connectHandler: ((ev: CustomEvent) => void) | null = null;
 
   @action
   onDidInsertElement(element: HTMLDivElement) {
-    this.rfb = new RFB(element, this.args.deviceFarmURL, {
-      credentials: {
-        password: this.args.deviceFarmPassword,
-      },
+    const url = this.args.deviceFarmURL;
+
+    if (!url) {
+      return;
+    }
+
+    try {
+      const password = this.args.deviceFarmPassword;
+      const options = password ? { credentials: { password } } : undefined;
+
+      this.rfb = new RFB(element, url, options);
+    } catch {
+      return;
+    }
+
+    const rfb = this.rfb;
+
+    if (!rfb) {
+      return;
+    }
+
+    rfb.viewOnly = !this.args.allowInteraction;
+
+    // One-shot: scale the viewport once the handshake completes, then
+    // self-remove. Tracked on the instance so willDestroy can also remove
+    // it if teardown beats the handshake.
+    const connectHandler = (this.connectHandler = () => {
+      rfb.removeEventListener('connect', connectHandler);
+
+      rfb.scaleViewport = true;
+      rfb._display.autoscale(element.offsetWidth, element.offsetHeight);
     });
 
-    this.rfb.viewOnly = !this.args.allowInteraction;
-
-    this.rfb.addEventListener('connect', () => {
-      const sizing_element = element;
-
-      this.rfb.scaleViewport = true;
-
-      this.rfb._display.autoscale(
-        sizing_element.offsetWidth,
-        sizing_element.offsetHeight
-      );
-    });
+    rfb.addEventListener('connect', connectHandler);
   }
 
   @action
   onWillDestroyElement() {
-    this.rfb?.removeEventListener('connect', () => {
-      this.rfb?.disconnect();
+    if (!this.rfb) {
+      return;
+    }
 
-      this.rfb = null;
-    });
+    // RFB.disconnect() only tears down its internal socket listeners; it
+    // does not clear listeners registered via addEventListener. Remove
+    // ours explicitly so the handler cannot fire against a destroyed
+    // element if the handshake completes mid-teardown.
+    if (this.connectHandler) {
+      this.rfb.removeEventListener('connect', this.connectHandler);
+    }
+
+    try {
+      this.rfb.disconnect();
+    } catch {
+      // already disconnected
+    }
+
+    this.rfb = null;
+    this.connectHandler = null;
   }
 }
 

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -58,61 +58,100 @@
     {{/if}}
   {{/if}}
 
-  <div data-test-vncViewer-device class='marvel-device {{this.deviceType}}'>
-    {{#if this.isTablet}}
-      <div data-test-vncViewer-deviceTopBar class='top-bar' />
-      <div data-test-vncViewer-deviceSleep class='sleep' />
-      <div data-test-vncViewer-deviceVolume class='volume' />
-    {{/if}}
-
-    <div data-test-vncViewer-deviceCamera class='camera' />
-
-    {{#if this.isIOSDevice}}
-      {{#if this.isTablet}}
-        <div data-test-vncViewer-deviceSpeaker class='speaker' />
-      {{/if}}
-    {{/if}}
-
-    <div data-test-vncViewer-deviceScreen class='screen'>
-      {{#if this.isAutomated}}
-        {{#if
-          (or
-            @dynamicScan.isStartingOrShuttingInProgress
-            @dynamicScan.isReadyOrRunning
-          )
-        }}
-          <AkStack
-            data-test-vncViewer-automatedNote
-            local-class='automated-scan-vnc-note'
-          >
-            <AkTypography @color='inherit'>
-              <strong>{{t 'note'}}</strong>
-              -
-              {{t
-                (if
-                  @dynamicScan.isInqueue
-                  'automatedScanQueuedVncNote'
-                  'automatedScanRunningVncNote'
-                )
-              }}
-            </AkTypography>
-          </AkStack>
+  {{#if this.supportsModernIOSDeviceFrame}}
+    <div data-test-vncViewer-device class='ios-device-frame'>
+      <div data-test-vncViewer-deviceScreen class='ios-device-screen'>
+        {{#if this.isAutomated}}
+          {{#if
+            (or
+              @dynamicScan.isStartingOrShuttingInProgress
+              @dynamicScan.isReadyOrRunning
+            )
+          }}
+            <AkStack
+              data-test-vncViewer-automatedNote
+              local-class='automated-scan-vnc-note'
+            >
+              <AkTypography @color='inherit'>
+                <strong>{{t 'note'}}</strong>
+                -
+                {{t
+                  (if
+                    @dynamicScan.isInqueue
+                    'automatedScanQueuedVncNote'
+                    'automatedScanRunningVncNote'
+                  )
+                }}
+              </AkTypography>
+            </AkStack>
+          {{/if}}
+        {{else if @dynamicScan.isReadyOrRunning}}
+          <NovncRfb
+            @allowInteraction={{@dynamicScan.isReady}}
+            @deviceFarmURL={{this.deviceFarmURL}}
+            @deviceFarmPassword={{this.deviceFarmPassword}}
+            @containCanvas={{true}}
+          />
         {{/if}}
-      {{else if @dynamicScan.isReadyOrRunning}}
-        <NovncRfb
-          @allowInteraction={{@dynamicScan.isReady}}
-          @deviceFarmURL={{this.deviceFarmURL}}
-          @deviceFarmPassword={{this.deviceFarmPassword}}
-        />
+      </div>
+    </div>
+  {{else}}
+    <div data-test-vncViewer-device class='marvel-device {{this.deviceType}}'>
+      {{#if this.isTablet}}
+        <div data-test-vncViewer-deviceTopBar class='top-bar' />
+        <div data-test-vncViewer-deviceSleep class='sleep' />
+        <div data-test-vncViewer-deviceVolume class='volume' />
+      {{/if}}
+
+      <div data-test-vncViewer-deviceCamera class='camera' />
+
+      {{#if this.isIOSDevice}}
+        {{#if this.isTablet}}
+          <div data-test-vncViewer-deviceSpeaker class='speaker' />
+        {{/if}}
+      {{/if}}
+
+      <div data-test-vncViewer-deviceScreen class='screen'>
+        {{#if this.isAutomated}}
+          {{#if
+            (or
+              @dynamicScan.isStartingOrShuttingInProgress
+              @dynamicScan.isReadyOrRunning
+            )
+          }}
+            <AkStack
+              data-test-vncViewer-automatedNote
+              local-class='automated-scan-vnc-note'
+            >
+              <AkTypography @color='inherit'>
+                <strong>{{t 'note'}}</strong>
+                -
+                {{t
+                  (if
+                    @dynamicScan.isInqueue
+                    'automatedScanQueuedVncNote'
+                    'automatedScanRunningVncNote'
+                  )
+                }}
+              </AkTypography>
+            </AkStack>
+          {{/if}}
+        {{else if @dynamicScan.isReadyOrRunning}}
+          <NovncRfb
+            @allowInteraction={{@dynamicScan.isReady}}
+            @deviceFarmURL={{this.deviceFarmURL}}
+            @deviceFarmPassword={{this.deviceFarmPassword}}
+          />
+        {{/if}}
+      </div>
+
+      {{#if this.isIOSDevice}}
+        <div data-test-vncViewer-deviceHome class='home' />
+
+        {{#if this.isTablet}}
+          <div data-test-vncViewer-deviceBottomBar class='bottom-bar' />
+        {{/if}}
       {{/if}}
     </div>
-
-    {{#if this.isIOSDevice}}
-      <div data-test-vncViewer-deviceHome class='home' />
-
-      {{#if this.isTablet}}
-        <div data-test-vncViewer-deviceBottomBar class='bottom-bar' />
-      {{/if}}
-    {{/if}}
-  </div>
+  {{/if}}
 </AkStack>

--- a/app/components/vnc-viewer/index.ts
+++ b/app/components/vnc-viewer/index.ts
@@ -8,6 +8,10 @@ import ENV from 'irene/config/environment';
 import type FileModel from 'irene/models/file';
 import type DynamicscanModel from 'irene/models/dynamicscan';
 import type DevicefarmService from 'irene/services/devicefarm';
+import {
+  IOS_MODERN_DEVICE_VERSION_CUTOFF,
+  getPlatformMajorVersion,
+} from 'irene/utils/dynamic-scan-device';
 
 export interface VncViewerSignature {
   Args: {
@@ -26,8 +30,6 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
   @service declare store: Store;
   @service declare devicefarm: DevicefarmService;
 
-  deviceFarmPassword = ENV.deviceFarmPassword;
-
   get deviceFarmURL() {
     const token = this.args.dynamicScan?.get('moriartyDynamicscanToken');
 
@@ -40,6 +42,24 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
 
   get deviceUsed() {
     return this.args.dynamicScan?.get('deviceUsed');
+  }
+
+  get supportsModernIOSDeviceFrame() {
+    if (!this.isIOSDevice) {
+      return false;
+    }
+
+    const majorVersion = getPlatformMajorVersion(
+      this.deviceUsed?.platform_version
+    );
+
+    return (
+      majorVersion !== null && majorVersion >= IOS_MODERN_DEVICE_VERSION_CUTOFF
+    );
+  }
+
+  get deviceFarmPassword() {
+    return this.supportsModernIOSDeviceFrame ? null : ENV.deviceFarmPassword;
   }
 
   get deviceType() {

--- a/app/services/event-bus.ts
+++ b/app/services/event-bus.ts
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import Evented from '@ember/object/evented';
 import type AnalysisOverviewModel from 'irene/models/analysis-overview';
+import type DynamicscanModel from 'irene/models/dynamicscan';
 import type { EmberMethod } from 'ember/-private/type-utils';
 
 /**
@@ -10,6 +11,9 @@ import type { EmberMethod } from 'ember/-private/type-utils';
 export interface EventBusEventMap {
   /** Triggered when a new message for websocket message for analysis-overview is received */
   'ws:analysis-overview:update': [analysis: AnalysisOverviewModel];
+
+  /** Triggered when a websocket update message for a dynamicscan is received */
+  'ws:dynamicscan:update': [dynamicscan: DynamicscanModel];
 }
 
 type EventBusSupportedEventNames = keyof EventBusEventMap;

--- a/app/styles/_devices.scss
+++ b/app/styles/_devices.scss
@@ -2963,3 +2963,21 @@
     }
   }
 }
+
+.ios-device-frame {
+  display: inline-block;
+  position: relative;
+  background: #1a1a1a;
+  border-radius: 24px;
+  padding: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+}
+
+.ios-device-screen {
+  width: 375px;
+  height: 812px;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #000;
+  position: relative;
+}

--- a/app/utils/dynamic-scan-device.ts
+++ b/app/utils/dynamic-scan-device.ts
@@ -1,0 +1,43 @@
+import type FileModel from 'irene/models/file';
+import ENUMS from 'irene/enums';
+
+export const IOS_MODERN_DEVICE_VERSION_CUTOFF = 17;
+
+// Sentinel ceiling for legacy iOS apps. Sent as `platform_version_max` so the
+// backend (moriarty2) returns only devices on iOS < 17, while still including
+// any minor/patch under 17 (e.g. 16.7.10). Keep > any real 16.x.y.
+const LEGACY_IOS_MAX_VERSION = '16.99.99';
+
+export function getPlatformMajorVersion(platformVersion?: string | null) {
+  const majorVersion = /\d+/.exec(platformVersion ?? '')?.[0];
+
+  return majorVersion ? Number.parseInt(majorVersion, 10) : null;
+}
+
+export interface AvailableManualDeviceVersionParams {
+  platform_version_min?: string;
+  platform_version_max?: string;
+}
+
+export function getIOSManualDeviceVersionParams(
+  file: FileModel
+): AvailableManualDeviceVersionParams {
+  if (file.project.get('platform') !== ENUMS.PLATFORM.IOS) {
+    return {};
+  }
+
+  const minOsVersion = file.minOsVersion;
+  const minMajorVersion = getPlatformMajorVersion(minOsVersion);
+  const isModernApp =
+    minMajorVersion !== null &&
+    minMajorVersion >= IOS_MODERN_DEVICE_VERSION_CUTOFF;
+
+  if (isModernApp) {
+    return { platform_version_min: minOsVersion as string };
+  }
+
+  return {
+    ...(minOsVersion ? { platform_version_min: minOsVersion } : {}),
+    platform_version_max: LEGACY_IOS_MAX_VERSION,
+  };
+}

--- a/app/utils/ws-model-ev-handlers.ts
+++ b/app/utils/ws-model-ev-handlers.ts
@@ -57,12 +57,21 @@ export class DynamicScanEventHandler extends WsModelEventHandler<DynamicscanMode
     this.realtime.incrementProperty('FileAutoDynamicScanReloadCounter');
   }
 
+  private pushDynamicscanAndNotify(wsData: object) {
+    const normalized = this.store.normalize('dynamicscan', wsData);
+    const dynamicscan = this.store.push(normalized) as DynamicscanModel;
+
+    this.eventBus.trigger('ws:dynamicscan:update', dynamicscan);
+  }
+
   // Perform all dynamic scan related actions when a dynamic scan is created
   onCreate() {
     this.incrementFileAutoDynamicScanReloadCounter();
   }
 
-  onUpdate() {}
+  onUpdate(wsData: object) {
+    this.pushDynamicscanAndNotify(wsData);
+  }
 }
 
 /** Handler for submission model events*/

--- a/tests/acceptance/file-details/dynamic-scan-test.js
+++ b/tests/acceptance/file-details/dynamic-scan-test.js
@@ -3,6 +3,7 @@ import {
   currentURL,
   find,
   findAll,
+  settled,
   visit,
   waitUntil,
 } from '@ember/test-helpers';
@@ -166,6 +167,7 @@ class NotificationsStub extends Service {
 
 // helper function to create a dynamic scan status helper
 function createDynamicScanStatusHelper(owner, dynamicscan) {
+  const store = owner.lookup('service:store');
   const websocket = owner.lookup('service:websocket');
 
   return async function assertScanStatus(
@@ -177,16 +179,31 @@ function createDynamicScanStatusHelper(owner, dynamicscan) {
     // Update server status
     dynamicscan.update({ status });
 
-    // Simulate websocket message
-    websocket.onObject({ id: dynamicscan.id, type: 'dynamicscan' });
+    websocket.onConnect();
 
-    // Wait for status text to update
+    websocket.onModelNotification({
+      model_name: 'dynamicscan',
+      data: dynamicscan.toJSON(),
+    });
+
+    await settled();
+
     await waitUntil(() => {
+      const storeScan = store.peekRecord('dynamicscan', String(dynamicscan.id));
       const statusEl = find('[data-test-fileDetails-dynamicScan-statusChip]');
+      const actionEl = expectedAction
+        ? find(`[data-test-fileDetails-dynamicScanAction="${expectedAction}"]`)
+        : null;
 
-      return expectedStatusText
+      const statusMatches = expectedStatusText
         ? statusEl?.textContent.includes(expectedStatusText)
         : !statusEl;
+
+      return (
+        storeScan?.status === status &&
+        statusMatches &&
+        (!expectedAction || !actionEl?.disabled)
+      );
     });
 
     // Assert status chip text

--- a/tests/integration/components/file-details/dynamic-scan/manual-test.js
+++ b/tests/integration/components/file-details/dynamic-scan/manual-test.js
@@ -3,6 +3,7 @@ import {
   find,
   findAll,
   render,
+  settled,
   triggerEvent,
 } from '@ember/test-helpers';
 
@@ -60,6 +61,7 @@ module(
         project: '1',
         profile: profile.id,
         is_active: true,
+        min_os_version: '15.0',
         last_automated_dynamic_scan: null,
         last_manual_dynamic_scan: null,
       });
@@ -67,6 +69,7 @@ module(
       const project = this.server.create('project', {
         last_file: file,
         id: '1',
+        platform: ENUMS.PLATFORM.IOS,
       });
 
       const availableDevices = this.server.createList(
@@ -484,6 +487,318 @@ module(
 
       // Verify final selection
       assert.dom(deviceSelectRadioSelector, deviceElemList[1]).isChecked();
+    });
+
+    test('it enables start after selecting a visible available specific device', async function (assert) {
+      this.devicePreference.update({
+        ds_manual_device_selection: ENUMS.DS_MANUAL_DEVICE_SELECTION.ANY_DEVICE,
+        ds_manual_device_identifier: '',
+      });
+
+      this.server.get(
+        '/v2/profiles/:id/ds_manual_device_preference',
+        (schema, req) => {
+          return schema.dsManualDevicePreferences
+            .find(`${req.params.id}`)
+            ?.toJSON();
+        }
+      );
+
+      this.server.put(
+        '/v2/profiles/:id/ds_manual_device_preference',
+        (schema, req) => {
+          return schema.db.dsManualDevicePreferences.update(
+            req.params.id,
+            JSON.parse(req.requestBody)
+          );
+        }
+      );
+
+      this.server.get(
+        '/v2/projects/:id/available_manual_devices',
+        (schema, req) => {
+          const hasTablePagination = 'limit' in req.queryParams;
+          const results = hasTablePagination
+            ? schema.availableManualDevices.all().models
+            : [];
+
+          return { count: results.length, next: null, previous: null, results };
+        }
+      );
+
+      this.server.get('/profiles/:id', (schema, req) =>
+        schema.profiles.find(`${req.params.id}`)?.toJSON()
+      );
+
+      this.server.get('/profiles/:id/api_scan_options', (_, req) => {
+        return { ds_api_capture_filters: [], id: req.params.id };
+      });
+
+      this.server.get('/profiles/:id/proxy_settings', (_, req) => {
+        return { id: req.params.id, host: '', port: '', enabled: false };
+      });
+
+      await render(hbs`
+        <FileDetails::DynamicScan::Manual @file={{this.file}} @dynamicScanText={{this.dynamicScanText}} />
+      `);
+
+      await click('[data-test-fileDetails-dynamicScanAction="startBtn"]');
+
+      await selectChoose(
+        `[data-test-fileDetails-dynamicScanDrawer-manualDast-devicePrefSelect] .${classes.trigger}`,
+        t(
+          dsManualDevicePref([ENUMS.DS_MANUAL_DEVICE_SELECTION.SPECIFIC_DEVICE])
+        )
+      );
+
+      assert
+        .dom('[data-test-fileDetails-dynamicScanDrawer-startBtn]')
+        .isDisabled();
+
+      const deviceElemList = findAll(
+        '[data-test-fileDetails-dynamicScanDrawer-devicePrefTable-row]'
+      );
+
+      assert.strictEqual(deviceElemList.length, this.availableDevices.length);
+
+      const deviceSelectRadioSelector =
+        '[data-test-fileDetails-dynamicScanDrawer-devicePrefTable-deviceSelectRadioInput]';
+
+      await click(deviceElemList[0].querySelector(deviceSelectRadioSelector));
+
+      assert
+        .dom('[data-test-fileDetails-dynamicScanDrawer-startBtn]')
+        .isNotDisabled();
+    });
+
+    test.each(
+      'it sends the right platform_version range based on the app minOsVersion',
+      [
+        {
+          minOsVersion: '15.0',
+          expectedMin: '15.0',
+          expectedMax: '16.99.99',
+          expectedDeviceIdentifiers: ['IOS166DEVICE', 'IOS16DEVICE'],
+          excludedDeviceIdentifiers: ['IOS14DEVICE', 'IOS17DEVICE'],
+        },
+        {
+          minOsVersion: '16.7',
+          expectedMin: '16.7',
+          expectedMax: '16.99.99',
+          expectedDeviceIdentifiers: ['IOS16DEVICE'],
+          excludedDeviceIdentifiers: [
+            'IOS14DEVICE',
+            'IOS166DEVICE',
+            'IOS17DEVICE',
+          ],
+        },
+        {
+          minOsVersion: '17.0',
+          expectedMin: '17.0',
+          expectedMax: undefined,
+          expectedDeviceIdentifiers: ['IOS17DEVICE'],
+          excludedDeviceIdentifiers: [
+            'IOS14DEVICE',
+            'IOS166DEVICE',
+            'IOS16DEVICE',
+          ],
+        },
+      ],
+      async function (
+        assert,
+        {
+          minOsVersion,
+          expectedMin,
+          expectedMax,
+          expectedDeviceIdentifiers,
+          excludedDeviceIdentifiers,
+        }
+      ) {
+        this.file.set('minOsVersion', minOsVersion);
+
+        const tooOldDevice = this.server.create('available-manual-device', {
+          device_identifier: 'IOS14DEVICE',
+          platform_version: '14.8',
+          platform: ENUMS.PLATFORM.IOS,
+        });
+
+        const oldLegacyDevice = this.server.create('available-manual-device', {
+          device_identifier: 'IOS166DEVICE',
+          platform_version: '16.6',
+          platform: ENUMS.PLATFORM.IOS,
+        });
+
+        const legacyDevice = this.server.create('available-manual-device', {
+          device_identifier: 'IOS16DEVICE',
+          platform_version: '16.7.10',
+          platform: ENUMS.PLATFORM.IOS,
+        });
+
+        const modernDevice = this.server.create('available-manual-device', {
+          device_identifier: 'IOS17DEVICE',
+          platform_version: '17.0',
+          platform: ENUMS.PLATFORM.IOS,
+        });
+
+        const allDevices = [
+          tooOldDevice,
+          oldLegacyDevice,
+          legacyDevice,
+          modernDevice,
+        ];
+
+        let drawerQueryParams;
+        let tableQueryParams;
+
+        this.server.get(
+          '/v2/profiles/:id/ds_manual_device_preference',
+          (schema, req) => {
+            return schema.dsManualDevicePreferences
+              .find(`${req.params.id}`)
+              ?.toJSON();
+          }
+        );
+
+        // Mimic moriarty2's padded-version range filter so the mock
+        // honors platform_version_min/max the same way prod does.
+        const padVersion = (v) =>
+          (v ?? '')
+            .split(' ', 1)[0]
+            .split('.')
+            .map((part) => part.padStart(11, '0'))
+            .join('.');
+
+        this.server.get(
+          '/v2/projects/:id/available_manual_devices',
+          (schema, req) => {
+            if ('limit' in req.queryParams) {
+              tableQueryParams = req.queryParams;
+            } else {
+              drawerQueryParams = req.queryParams;
+            }
+
+            const min = req.queryParams.platform_version_min;
+            const max = req.queryParams.platform_version_max;
+
+            const results = allDevices.filter((device) => {
+              const padded = padVersion(device.platform_version);
+
+              if (min && padded < padVersion(min)) {
+                return false;
+              }
+
+              if (max && padded > padVersion(max)) {
+                return false;
+              }
+
+              return true;
+            });
+
+            return {
+              count: results.length,
+              next: null,
+              previous: null,
+              results,
+            };
+          }
+        );
+
+        this.server.get('/profiles/:id', (schema, req) =>
+          schema.profiles.find(`${req.params.id}`)?.toJSON()
+        );
+
+        this.server.get('/profiles/:id/api_scan_options', (_, req) => {
+          return { ds_api_capture_filters: [], id: req.params.id };
+        });
+
+        this.server.get('/profiles/:id/proxy_settings', (_, req) => {
+          return { id: req.params.id, host: '', port: '', enabled: false };
+        });
+
+        await render(hbs`
+          <FileDetails::DynamicScan::Manual @file={{this.file}} @dynamicScanText={{this.dynamicScanText}} />
+        `);
+
+        await click('[data-test-fileDetails-dynamicScanAction="startBtn"]');
+
+        assert.ok(drawerQueryParams, 'drawer query params should be captured');
+        assert.ok(tableQueryParams, 'table query params should be captured');
+
+        assert.strictEqual(
+          drawerQueryParams?.platform_version_min,
+          expectedMin
+        );
+        assert.strictEqual(tableQueryParams?.platform_version_min, expectedMin);
+
+        assert.strictEqual(
+          drawerQueryParams?.platform_version_max,
+          expectedMax
+        );
+        assert.strictEqual(tableQueryParams?.platform_version_max, expectedMax);
+
+        const deviceElemList = findAll(
+          '[data-test-fileDetails-dynamicScanDrawer-devicePrefTable-row]'
+        );
+
+        const renderedDeviceText = deviceElemList
+          .map((element) => element.textContent)
+          .join(' ');
+
+        assert.strictEqual(
+          deviceElemList.length,
+          expectedDeviceIdentifiers.length
+        );
+
+        expectedDeviceIdentifiers.forEach((identifier) => {
+          assert.true(
+            renderedDeviceText.includes(identifier),
+            `${identifier} should be visible`
+          );
+        });
+
+        excludedDeviceIdentifiers.forEach((identifier) => {
+          assert.false(
+            renderedDeviceText.includes(identifier),
+            `${identifier} should not be visible`
+          );
+        });
+      }
+    );
+
+    test('it reloads the active manual scan from realtime updates', async function (assert) {
+      await render(hbs`
+        <FileDetails::DynamicScan::Manual @file={{this.file}} @dynamicScanText={{this.dynamicScanText}} />
+      `);
+
+      assert
+        .dom('[data-test-fileDetails-dynamicScanAction="startBtn"]')
+        .exists();
+
+      const queuedScan = this.server.create('dynamicscan', {
+        file: this.file.id,
+        mode: ENUMS.DYNAMIC_MODE.MANUAL,
+        status: ENUMS.DYNAMIC_SCAN_STATUS.IN_QUEUE,
+        ended_on: null,
+      });
+
+      const store = this.owner.lookup('service:store');
+      const eventBus = this.owner.lookup('service:event-bus');
+
+      const dynamicscan = store.push(
+        store.normalize('dynamicscan', queuedScan.toJSON())
+      );
+
+      eventBus.trigger('ws:dynamicscan:update', dynamicscan);
+
+      await settled();
+
+      assert
+        .dom('[data-test-fileDetails-dynamicScanAction="cancelBtn"]')
+        .exists();
+
+      assert
+        .dom('[data-test-fileDetails-dynamicScanAction="startBtn"]')
+        .doesNotExist();
     });
 
     test.each(

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -6,6 +6,10 @@ import { setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import ENUMS from 'irene/enums';
+import {
+  IOS_MODERN_DEVICE_VERSION_CUTOFF,
+  getPlatformMajorVersion,
+} from 'irene/utils/dynamic-scan-device';
 
 module('Integration | Component | vnc-viewer', function (hooks) {
   setupRenderingTest(hooks);
@@ -98,12 +102,14 @@ module('Integration | Component | vnc-viewer', function (hooks) {
         platform: ENUMS.PLATFORM.IOS,
         isTablet: true,
         deviceClass: 'ipad black',
+        platformVersion: '16.7.10',
       },
       {
         platform: ENUMS.PLATFORM.IOS,
         isTablet: true,
         deviceClass: 'iphone5s black', // since device might not be allocated so show default
         status: ENUMS.DYNAMIC_SCAN_STATUS.IN_QUEUE,
+        platformVersion: '16.7.10',
       },
       {
         platform: ENUMS.PLATFORM.ANDROID,
@@ -114,12 +120,23 @@ module('Integration | Component | vnc-viewer', function (hooks) {
         platform: ENUMS.PLATFORM.IOS,
         isTablet: false,
         deviceClass: 'iphone5s black',
+        platformVersion: '16.7.10',
+      },
+      {
+        platform: ENUMS.PLATFORM.IOS,
+        isTablet: false,
+        deviceClass: 'iphone5s black',
+        platformVersion: '18.0',
       },
     ],
-    async function (assert, { platform, isTablet, deviceClass, status }) {
+    async function (
+      assert,
+      { platform, isTablet, deviceClass, platformVersion, status }
+    ) {
       const deviceUsed = this.server.create('device', {
         is_tablet: isTablet,
         platform,
+        platform_version: platformVersion,
       });
 
       const dynamicscan = this.server.create('dynamicscan', {
@@ -151,24 +168,41 @@ module('Integration | Component | vnc-viewer', function (hooks) {
         this.dynamicscan.isHooking ||
         this.dynamicscan.isReadyOrRunning;
 
-      deviceClass.split(' ').forEach((val) => {
-        assert.dom('[data-test-vncViewer-device]').hasClass(val);
-      });
+      const platformMajorVersion = getPlatformMajorVersion(platformVersion);
+      const usesModernIOSDeviceFrame =
+        platform === ENUMS.PLATFORM.IOS &&
+        platformMajorVersion !== null &&
+        platformMajorVersion >= IOS_MODERN_DEVICE_VERSION_CUTOFF;
+
+      if (usesModernIOSDeviceFrame) {
+        assert
+          .dom('[data-test-vncViewer-device]')
+          .doesNotHaveClass('marvel-device');
+        assert.dom('[data-test-vncViewer-deviceScreen]').exists();
+        assert.dom('[data-test-vncViewer-deviceCamera]').doesNotExist();
+        assert.dom('[data-test-vncViewer-deviceHome]').doesNotExist();
+      } else {
+        deviceClass.split(' ').forEach((val) => {
+          assert.dom('[data-test-vncViewer-device]').hasClass(val);
+        });
+
+        assert.dom('[data-test-vncViewer-deviceCamera]').exists();
+        assert.dom('[data-test-vncViewer-deviceScreen]').hasClass('screen');
+
+        if (platform === ENUMS.PLATFORM.IOS) {
+          assert.dom('[data-test-vncViewer-deviceHome]').exists();
+        }
+      }
 
       ['TopBar', 'Sleep', 'Volume'].forEach((it) => {
-        if (isScanInProgress && isTablet) {
+        if (!usesModernIOSDeviceFrame && isScanInProgress && isTablet) {
           assert.dom(`[data-test-vncViewer-device${it}]`).exists();
         } else {
           assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
         }
       });
 
-      assert.dom('[data-test-vncViewer-deviceCamera]').exists();
-      assert.dom('[data-test-vncViewer-deviceScreen]').hasClass('screen');
-
-      if (platform === ENUMS.PLATFORM.IOS) {
-        assert.dom('[data-test-vncViewer-deviceHome]').exists();
-
+      if (platform === ENUMS.PLATFORM.IOS && !usesModernIOSDeviceFrame) {
         ['Speaker', 'BottomBar'].forEach((it) => {
           if (isScanInProgress && isTablet) {
             assert.dom(`[data-test-vncViewer-device${it}]`).exists();
@@ -176,6 +210,15 @@ module('Integration | Component | vnc-viewer', function (hooks) {
             assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
           }
         });
+      }
+
+      if (this.dynamicscan.isReadyOrRunning) {
+        assert
+          .dom('[data-test-NovncRfb-canvasContainer]')
+          .hasAttribute(
+            'data-contain-canvas',
+            usesModernIOSDeviceFrame ? 'true' : 'false'
+          );
       }
     }
   );


### PR DESCRIPTION
  ## Summary

  This PR refines the dynamic scan device/VNC flow with support for newer iOS device behavior, more reliable realtime scan updates, and stronger test coverage around the updated
  socket path.

  ## Changes

  - Added iOS device version helpers for manual dynamic scan device selection.
    - Legacy iOS apps continue to request devices below iOS 17.
    - iOS 17+ apps request modern iOS devices using the app minimum OS version.

  - Updated the VNC viewer to support the modern iOS device frame.
    - Modern iOS devices render in the new iOS frame.
    - Legacy iOS and Android devices keep the existing `marvel-device` frame path.
    - noVNC password is skipped for modern iOS device frames and retained for the existing VNC path.

  - Hardened the noVNC RFB lifecycle.
    - Handles missing/invalid VNC URLs safely.
    - Makes the `connect` listener one-shot after successful handshake.
    - Explicitly removes the listener during teardown because `RFB.disconnect()` does not clear user-added EventTarget listeners.

  - Routed dynamic scan websocket updates through the event bus.
    - `model_updated` notifications now push the updated `dynamicscan` into the store and trigger `ws:dynamicscan:update`.
    - Manual and automated scan views reload their latest scan state from that event.

  - Improved manual device selection behavior.
    - The drawer tracks whether the currently selected specific device is available in the fetched device list.
    - Start remains disabled when a specific device is selected but unavailable.

  ## Tests

  - Added/updated integration coverage for:
    - iOS manual device version filtering.
    - Specific manual device selection and start-button enablement.
    - Manual scan realtime reload from websocket/event-bus updates.
    - Modern iOS VNC frame rendering.

  - Updated acceptance coverage to simulate the new `model_updated` websocket notification path instead of the old object event path.
