### PR TITLE
feat: add DORA Compliance Integration

### DIFF
--- a/app/adapters/dora.ts
+++ b/app/adapters/dora.ts
@@ -1,0 +1,11 @@
+import CommonDRFAdapter from './commondrf';
+
+export default class DoraAdapter extends CommonDRFAdapter {
+  namespace = this.namespace_v2;
+}
+
+declare module 'ember-data/types/registries/adapter' {
+  export default interface AdapterRegistry {
+    dora: DoraAdapter;
+  }
+}

--- a/app/components/file-details/vulnerability-analysis-details/index.ts
+++ b/app/components/file-details/vulnerability-analysis-details/index.ts
@@ -19,6 +19,7 @@ import type GdprModel from 'irene/models/gdpr';
 import type Nistsp80053Model from 'irene/models/nistsp80053';
 import type Nistsp800171Model from 'irene/models/nistsp800171';
 import type SamaModel from 'irene/models/sama';
+import type DoraModel from 'irene/models/dora';
 
 export interface FileDetailsVulnerabilityAnalysisDetailsSignature {
   Args: {
@@ -158,6 +159,14 @@ export default class FileDetailsVulnerabilityAnalysisDetailsComponent extends Co
         contents: this.analysis.sama?.content as SamaModel[],
         hasContent: this.analysis.showSama && !isEmpty(this.analysis.sama),
         hasMoreDetails: true,
+      },
+      {
+        key: 'dora',
+        heading: this.intl.t('dora'),
+        title: this.intl.t('doraExpansion'),
+        contents: this.analysis.dora?.content as DoraModel[],
+        hasContent: this.analysis.showDora && !isEmpty(this.analysis.dora),
+        hasMoreDetails: false,
       },
     ];
   }

--- a/app/components/knox-iq/vulnerability-analysis-details/index.ts
+++ b/app/components/knox-iq/vulnerability-analysis-details/index.ts
@@ -211,6 +211,14 @@ export default class KnoxIqVulnerabilityAnalysisDetailsComponent extends Compone
         hasContent: this.analysis.showSama && !isEmpty(this.analysis.sama),
         hasMoreDetails: true,
       },
+      {
+        key: 'dora',
+        heading: this.intl.t('dora'),
+        title: this.intl.t('doraExpansion'),
+        contents: this.analysis.dora,
+        hasContent: this.analysis.showDora && !isEmpty(this.analysis.dora),
+        hasMoreDetails: false,
+      },
     ];
   }
 

--- a/app/components/project-settings/analysis-settings/regulatory-preference/index.ts
+++ b/app/components/project-settings/analysis-settings/regulatory-preference/index.ts
@@ -81,6 +81,15 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
         isSaving: this.onSaveSama.isRunning,
         isOverriden: !this.profile?.reportPreference.show_sama?.is_inherited,
       },
+      {
+        label: this.intl.t('dora'),
+        title: this.intl.t('doraExpansion'),
+        value: this.profile?.reportPreference.show_dora?.value,
+        toggleHandler: this.onSaveDora,
+        resetHandler: this.onResetDora,
+        isSaving: this.onSaveDora.isRunning,
+        isOverriden: !this.profile?.reportPreference.show_dora?.is_inherited,
+      },
     ];
   }
 
@@ -153,6 +162,10 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
     await this.savePreference.perform(event, 'sama');
   });
 
+  onSaveDora = task(async (event: Event) => {
+    await this.savePreference.perform(event, 'dora');
+  });
+
   onResetPcidss = task(async () => {
     await this.resetPreference.perform('pcidss');
   });
@@ -171,6 +184,10 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
 
   onResetSama = task(async () => {
     await this.resetPreference.perform('sama');
+  });
+
+  onResetDora = task(async () => {
+    await this.resetPreference.perform('dora');
   });
 }
 

--- a/app/components/regulatory-preference-organization/index.ts
+++ b/app/components/regulatory-preference-organization/index.ts
@@ -25,34 +25,40 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
   get regulatoryPreferences() {
     return [
       {
-        label: 'PCI-DSS',
+        label: this.intl.t('pcidss'),
         checked: Boolean(this.orgPreference?.reportPreference.show_pcidss),
         task: this.savePcidss,
         title: this.intl.t('pcidssExpansion'),
       },
       {
-        label: 'HIPAA',
+        label: this.intl.t('hipaa'),
         checked: Boolean(this.orgPreference?.reportPreference.show_hipaa),
         task: this.saveHipaa,
         title: this.intl.t('hipaaExpansion'),
       },
       {
-        label: 'GDPR',
+        label: this.intl.t('gdpr'),
         checked: Boolean(this.orgPreference?.reportPreference.show_gdpr),
         task: this.saveGdpr,
         title: this.intl.t('gdprExpansion'),
       },
       {
-        label: 'NIST',
+        label: this.intl.t('nist'),
         checked: Boolean(this.orgPreference?.reportPreference?.show_nist),
         task: this.saveNist,
         title: this.intl.t('nistExpansion'),
       },
       {
-        label: 'SAMA',
+        label: this.intl.t('sama'),
         checked: Boolean(this.orgPreference?.reportPreference?.show_sama),
         task: this.saveSama,
         title: this.intl.t('samaExpansion'),
+      },
+      {
+        label: this.intl.t('dora'),
+        checked: Boolean(this.orgPreference?.reportPreference?.show_dora),
+        task: this.saveDora,
+        title: this.intl.t('doraExpansion'),
       },
     ];
   }
@@ -90,6 +96,10 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
     await this.saveReportPreference.perform('show_sama', event);
   });
 
+  saveDora = task(async (event) => {
+    await this.saveReportPreference.perform('show_dora', event);
+  });
+
   saveReportPreference = task(
     async (
       regulator:
@@ -97,7 +107,8 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
         | 'show_hipaa'
         | 'show_gdpr'
         | 'show_nist'
-        | 'show_sama',
+        | 'show_sama'
+        | 'show_dora',
       event
     ) => {
       const preference = this.orgPreference as OrganizationPreferenceModel;

--- a/app/components/security/analysis-details/index.ts
+++ b/app/components/security/analysis-details/index.ts
@@ -291,6 +291,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       nistsp800171,
       nistsp80053,
       sama,
+      dora,
     ] = await Promise.all([
       details?.owasp,
       details?.owaspmobile2024,
@@ -306,6 +307,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       details?.nistsp800171,
       details?.nistsp80053,
       details?.sama,
+      details?.dora,
     ]);
 
     // Normalise status: Ember Data may hand back a boxed object pre-save.
@@ -341,6 +343,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       nistsp80053: nistsp80053?.map((a) => a.id),
       nistsp800171: nistsp800171?.map((a) => a.id),
       sama: sama?.map((a) => a.id),
+      dora: dora?.map((a) => a.id),
       overridden_risk: overriddenRisk,
       overridden_risk_comment: details?.overriddenRiskComment,
       overridden_risk_to_profile: details?.overriddenRiskToProfile,

--- a/app/components/security/analysis-details/regulatory-categories/index.ts
+++ b/app/components/security/analysis-details/regulatory-categories/index.ts
@@ -25,6 +25,7 @@ import type Nistsp800171Model from 'irene/models/nistsp800171';
 import type IntlService from 'ember-intl/services/intl';
 import SamaModel from 'irene/models/sama';
 import Pcidss4Model from 'irene/models/pcidss4';
+import DoraModel from 'irene/models/dora';
 
 type RegulatoryCategoryOptionKeys =
   | 'owasp'
@@ -40,7 +41,8 @@ type RegulatoryCategoryOptionKeys =
   | 'gdpr'
   | 'nistsp800171'
   | 'nistsp80053'
-  | 'sama';
+  | 'sama'
+  | 'dora';
 
 type RegulatoryCategoryModels =
   | OwaspModel
@@ -56,7 +58,8 @@ type RegulatoryCategoryModels =
   | GdprModel
   | Nistsp80053Model
   | Nistsp800171Model
-  | SamaModel;
+  | SamaModel
+  | DoraModel;
 
 type RegulatoryDataModel<T> = ArrayProxy<T> | null;
 
@@ -86,6 +89,7 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
   @tracked nistsp80053sData: RegulatoryDataModel<Nistsp80053Model> = null;
   @tracked nistsp800171sData: RegulatoryDataModel<Nistsp800171Model> = null;
   @tracked samaData: RegulatoryDataModel<SamaModel> = null;
+  @tracked doraData: RegulatoryDataModel<DoraModel> = null;
 
   risks = ENUMS.RISK.CHOICES;
 
@@ -168,6 +172,10 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
 
   get sama() {
     return this.samaData?.slice() || [];
+  }
+
+  get doras() {
+    return this.doraData?.slice() || [];
   }
 
   get regulatoryCategories() {
@@ -300,6 +308,15 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
         options: this.sama,
         onChange: this.onCategorySelect('sama'),
       },
+      {
+        key: 'dora',
+        title: 'Digital Operational Resilience Act',
+        placeholder: 'Select DORA',
+        labelKeys: ['code', 'title'],
+        selected: this.analysis?.dora ?? [],
+        options: this.doras,
+        onChange: this.onCategorySelect('dora'),
+      },
     ] as Array<{
       key: string;
       title: string;
@@ -366,6 +383,8 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
       this.samaData = await this.store.findAll('sama');
 
       this.pcidss4sData = await this.store.findAll('pcidss4');
+
+      this.doraData = await this.store.findAll('dora');
     } catch (error) {
       this.notifications.error(parseError(error, this.tPleaseTryAgain));
     }

--- a/app/components/security/analysis-list/table/action/index.ts
+++ b/app/components/security/analysis-list/table/action/index.ts
@@ -102,6 +102,7 @@ export default class SecurityAnalysisListTableActionComponent extends Component<
             a.get('id')
           ),
           sama: (await this.analysis.sama).map((a) => a.get('id')),
+          dora: (await this.analysis.dora).map((a) => a.get('id')),
           findings: this.analysis.findings,
           overridden_risk: this.analysis.overriddenRisk || 'None',
           overridden_risk_comment: this.analysis.overriddenRiskComment || '',

--- a/app/models/analysis.ts
+++ b/app/models/analysis.ts
@@ -32,6 +32,7 @@ import Nistsp800171Model from './nistsp800171';
 import Nistsp80053Model from './nistsp80053';
 import SamaModel from './sama';
 import Pcidss4Model from './pcidss4';
+import DoraModel from './dora';
 import { KnoxiqValidatedFindingExploitability } from './knoxiq-validated-finding';
 
 irregular('asvs', 'asvses');
@@ -149,6 +150,9 @@ export default class AnalysisModel extends Model {
 
   @hasMany('sama', { async: true, inverse: null })
   declare sama: AsyncHasMany<SamaModel>;
+
+  @hasMany('dora', { async: true, inverse: null })
+  declare dora: AsyncHasMany<DoraModel>;
 
   @belongsTo('vulnerability', { async: true, inverse: null })
   declare vulnerability: AsyncBelongsTo<VulnerabilityModel>;
@@ -298,6 +302,10 @@ export default class AnalysisModel extends Model {
 
   get showSama() {
     return this.file.get('profile')?.get('reportPreference')?.show_sama?.value;
+  }
+
+  get showDora() {
+    return this.file.get('profile')?.get('reportPreference')?.show_dora?.value;
   }
 
   get vulnerabilityTypes() {

--- a/app/models/dora.ts
+++ b/app/models/dora.ts
@@ -1,0 +1,15 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class DoraModel extends Model {
+  @attr('string')
+  declare code: string;
+
+  @attr('string')
+  declare title: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+  export default interface ModelRegistry {
+    dora: DoraModel;
+  }
+}

--- a/app/models/organization-preference.ts
+++ b/app/models/organization-preference.ts
@@ -6,6 +6,7 @@ interface ReportPreferenceData {
   show_pcidss: boolean;
   show_nist: boolean;
   show_sama: boolean;
+  show_dora: boolean;
 }
 
 export default class OrganizationPreferenceModel extends Model {

--- a/app/models/profile.ts
+++ b/app/models/profile.ts
@@ -16,6 +16,7 @@ export interface ProfileReportPreference {
   show_gdpr: ValueObject;
   show_nist: ValueObject;
   show_sama: ValueObject;
+  show_dora: ValueObject;
 }
 
 export type SaveReportPreferenceData = Pick<
@@ -32,7 +33,8 @@ export type ProfileRegulatoryReportPreference =
   | 'hipaa'
   | 'gdpr'
   | 'nist'
-  | 'sama';
+  | 'sama'
+  | 'dora';
 
 type ProfileAdapterName = 'profile';
 

--- a/app/models/security/analysis.ts
+++ b/app/models/security/analysis.ts
@@ -28,6 +28,7 @@ import Nistsp80053Model from '../nistsp80053';
 import Nistsp800171Model from '../nistsp800171';
 import SamaModel from '../sama';
 import Pcidss4Model from '../pcidss4';
+import DoraModel from '../dora';
 
 irregular('asvs', 'asvses');
 
@@ -153,6 +154,9 @@ export default class SecurityAnalysisModel extends Model {
 
   @hasMany('sama', { async: true, inverse: null })
   declare sama: AsyncHasMany<SamaModel>;
+
+  @hasMany('dora', { async: true, inverse: null })
+  declare dora: AsyncHasMany<DoraModel>;
 
   @hasMany('security/attachment', { async: true, inverse: null })
   declare attachments: AsyncHasMany<SecurityAttachmentModel>;

--- a/mirage/factories/analysis.ts
+++ b/mirage/factories/analysis.ts
@@ -165,6 +165,14 @@ export default Factory.extend({
     },
   }),
 
+  withDora: trait({
+    afterCreate(model: ModelInstance, server: Server) {
+      model.update({
+        dora: server.createList('dora', 2).map((it) => it.id),
+      });
+    },
+  }),
+
   withAllRegulatory: trait({
     afterCreate(model: ModelInstance, server: Server) {
       model.update({
@@ -183,6 +191,7 @@ export default Factory.extend({
         nistsp80053: server.createList('nistsp80053', 2).map((it) => it.id),
         nistsp800171: server.createList('nistsp800171', 2).map((it) => it.id),
         sama: server.createList('sama', 2).map((it) => it.id),
+        dora: server.createList('dora', 2).map((it) => it.id),
       });
     },
   }),

--- a/mirage/factories/dora.ts
+++ b/mirage/factories/dora.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+export default Factory.extend({
+  code(i) {
+    return `dora_${i}`;
+  },
+
+  title() {
+    return faker.lorem.sentence();
+  },
+});

--- a/mirage/factories/organization-preference.ts
+++ b/mirage/factories/organization-preference.ts
@@ -8,5 +8,6 @@ export default Factory.extend({
     show_gdpr: faker.datatype.boolean(),
     show_nist: faker.datatype.boolean(),
     show_sama: faker.datatype.boolean(),
+    show_dora: faker.datatype.boolean(),
   }),
 });

--- a/mirage/factories/security/analysis.js
+++ b/mirage/factories/security/analysis.js
@@ -234,6 +234,14 @@ export default Factory.extend({
     },
   }),
 
+  withDora: trait({
+    afterCreate(model, server) {
+      model.update({
+        dora: server.createList('dora', 2).map((it) => it.id),
+      });
+    },
+  }),
+
   withAllRegulatory: trait({
     afterCreate(model, server) {
       model.update({
@@ -252,6 +260,7 @@ export default Factory.extend({
         nistsp80053: server.createList('nistsp80053', 2).map((it) => it.id),
         nistsp800171: server.createList('nistsp800171', 2).map((it) => it.id),
         sama: server.createList('sama', 2).map((it) => it.id),
+        dora: server.createList('dora', 2).map((it) => it.id),
       });
     },
   }),

--- a/tests/integration/components/file-details/vulnerability-analysis-details/index-test.js
+++ b/tests/integration/components/file-details/vulnerability-analysis-details/index-test.js
@@ -255,6 +255,10 @@ module(
         schema.samas.find(`${req.params.id}`)?.toJSON()
       );
 
+      this.server.get('/v2/doras/:id', (schema, req) =>
+        schema.doras.find(`${req.params.id}`)?.toJSON()
+      );
+
       await render(
         hbs`<FileDetails::VulnerabilityAnalysisDetails @analysis={{this.analysis}} />`
       );
@@ -1165,6 +1169,10 @@ module(
           schema.samas.find(`${req.params.id}`)?.toJSON()
         );
 
+        this.server.get('/v2/doras/:id', (schema, req) =>
+          schema.doras.find(`${req.params.id}`)?.toJSON()
+        );
+
         await render(
           hbs`<FileDetails::VulnerabilityAnalysisDetails @analysis={{this.analysis}} />`
         );
@@ -1292,6 +1300,10 @@ module(
 
       this.server.get('/v2/samas/:id', (schema, req) =>
         schema.samas.find(`${req.params.id}`)?.toJSON()
+      );
+
+      this.server.get('/v2/doras/:id', (schema, req) =>
+        schema.doras.find(`${req.params.id}`)?.toJSON()
       );
 
       await render(
@@ -1437,6 +1449,7 @@ module(
           'nistsp800171',
           null,
         ],
+        ['withDora', 'v2/doras', 'doras', 'dora', null],
       ],
       async function (
         assert,
@@ -1507,6 +1520,10 @@ module(
               },
               show_sama: {
                 value: modelKey === 'sama',
+                is_inherited: false,
+              },
+              show_dora: {
+                value: modelKey === 'dora',
                 is_inherited: false,
               },
             },
@@ -1588,6 +1605,8 @@ module(
         ['nistsp800171'],
         ['sama', []],
         ['sama'],
+        ['dora', []],
+        ['dora'],
       ],
       async function (assert, [modelKey, modelValue]) {
         const vulnerability = this.store.push(
@@ -1641,6 +1660,7 @@ module(
           ['v2/nistsp80053s', 'nistsp80053s', 'nistsp80053'],
           ['v2/nistsp800171s', 'nistsp800171s', 'nistsp800171'],
           ['v2/samas', 'samas', 'sama'],
+          ['v2/doras', 'doras', 'dora'],
         ].forEach(([urlParam, schemaKey, key, isJsonApi]) => {
           if (key !== modelKey) {
             this.server.get(`/${urlParam}/:id`, (schema, req) => {

--- a/tests/integration/components/project-settings/analysis-settings/regulatory-preference-test.js
+++ b/tests/integration/components/project-settings/analysis-settings/regulatory-preference-test.js
@@ -144,6 +144,7 @@ module(
         t('gdpr'),
         t('nist'),
         t('sama'),
+        t('dora'),
       ];
 
       optionalRegulatoriesLabels.map((regLabel) =>
@@ -175,6 +176,10 @@ module(
             is_inherited: false,
           },
           show_sama: {
+            value: false,
+            is_inherited: false,
+          },
+          show_dora: {
             value: false,
             is_inherited: false,
           },
@@ -259,6 +264,21 @@ module(
         return profile.report_preference.show_sama;
       });
 
+      this.server.put('profiles/:id/show_dora', (schema, request) => {
+        const body = JSON.parse(request.requestBody);
+
+        const profile = schema['profiles'].find(request.params.id);
+
+        profile.report_preference.show_dora = {
+          value: body.value,
+          is_inherited: false,
+        };
+
+        profile.save();
+
+        return profile.report_preference.show_dora;
+      });
+
       await render(
         hbs`<ProjectSettings::AnalysisSettings::RegulatoryPreference @project={{this.project}}/>`
       );
@@ -322,6 +342,19 @@ module(
       await click(samaInput);
 
       assert.strictEqual(samaInput.checked, !samaInitialValue);
+
+      const dora = this.element.querySelector(
+        `[data-test-projectSetting-analysisSettings-regulatoryPreferences="${t('dora')}"]`
+      );
+
+      const doraInitialValue = profile.report_preference.show_dora.value;
+      const doraInput = dora.querySelector('[data-test-input]');
+
+      assert.strictEqual(doraInput.checked, doraInitialValue);
+
+      await click(doraInput);
+
+      assert.strictEqual(doraInput.checked, !doraInitialValue);
     });
 
     test('it does not toggle preference value on error', async function (assert) {
@@ -344,6 +377,10 @@ module(
             is_inherited: false,
           },
           show_sama: {
+            value: false,
+            is_inherited: false,
+          },
+          show_dora: {
             value: false,
             is_inherited: false,
           },
@@ -380,6 +417,10 @@ module(
       });
 
       this.server.put('profiles/:id/show_sama', () => {
+        return new Response(400, {}, { value: ['Must be a valid boolean.'] });
+      });
+
+      this.server.put('profiles/:id/show_dora', () => {
         return new Response(400, {}, { value: ['Must be a valid boolean.'] });
       });
 
@@ -445,6 +486,19 @@ module(
       await click(samaInput);
 
       assert.strictEqual(samaInput.checked, samaInitialValue);
+
+      const dora = this.element.querySelector(
+        `[data-test-projectSetting-analysisSettings-regulatoryPreferences="${t('dora')}"]`
+      );
+
+      const doraInitialValue = profile.report_preference.show_dora.value;
+      const doraInput = dora.querySelector('[data-test-input]');
+
+      assert.strictEqual(doraInput.checked, doraInitialValue);
+
+      await click(doraInput);
+
+      assert.strictEqual(doraInput.checked, doraInitialValue);
     });
 
     test('it displays overridden state with reset button if a preference is updated', async function (assert) {

--- a/tests/integration/components/regulatory-preference-organization-test.js
+++ b/tests/integration/components/regulatory-preference-organization-test.js
@@ -82,6 +82,10 @@ module(
       assert
         .dom('[data-test-ak-form-label]', find('[data-test-preference="SAMA"]'))
         .hasText('SAMA');
+
+      assert
+        .dom('[data-test-ak-form-label]', find('[data-test-preference="DORA"]'))
+        .hasText('DORA');
     });
 
     test('it renders regulatory list tooltip', async function (assert) {
@@ -96,6 +100,7 @@ module(
       const gdprContainer = find('[data-test-preference="GDPR"]');
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
+      const doraContainer = find('[data-test-preference="DORA"]');
 
       // pci-dss
       await triggerEvent(
@@ -173,6 +178,21 @@ module(
       );
 
       assert.dom('[data-test-ak-tooltip-content]').doesNotExist();
+
+      // dora
+      await triggerEvent(
+        `#${doraContainer.id} [data-test-ak-tooltip-root]`,
+        'mouseenter'
+      );
+
+      assert.dom('[data-test-ak-tooltip-content]').hasText(t('doraExpansion'));
+
+      await triggerEvent(
+        `#${doraContainer.id} [data-test-ak-tooltip-root]`,
+        'mouseleave'
+      );
+
+      assert.dom('[data-test-ak-tooltip-content]').doesNotExist();
     });
 
     test('it renders regulatory inclusion status based on organization preference', async function (assert) {
@@ -183,6 +203,7 @@ module(
         json.report_preference.show_gdpr = true;
         json.report_preference.show_nist = true;
         json.report_preference.show_sama = true;
+        json.report_preference.show_dora = false;
 
         return json;
       });
@@ -223,6 +244,13 @@ module(
           find('[data-test-preference="SAMA"]')
         )
         .isChecked();
+
+      assert
+        .dom(
+          '[data-test-preference-checkbox]',
+          find('[data-test-preference="DORA"]')
+        )
+        .isNotChecked();
     });
 
     test('it toggles regulatory preference on label click', async function (assert) {
@@ -233,6 +261,7 @@ module(
         json.report_preference.show_gdpr = false;
         json.report_preference.show_nist = false;
         json.report_preference.show_sama = false;
+        json.report_preference.show_dora = false;
 
         return json;
       });
@@ -256,6 +285,7 @@ module(
       const gdprContainer = find('[data-test-preference="GDPR"]');
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
+      const doraContainer = find('[data-test-preference="DORA"]');
 
       assert
         .dom('[data-test-preference-checkbox]', pcidssContainer)
@@ -279,6 +309,11 @@ module(
 
       assert
         .dom('[data-test-preference-checkbox]', samaContainer)
+        .isNotDisabled()
+        .isNotChecked();
+
+      assert
+        .dom('[data-test-preference-checkbox]', doraContainer)
         .isNotDisabled()
         .isNotChecked();
 
@@ -304,6 +339,10 @@ module(
 
       assert.dom('[data-test-preference-checkbox]', samaContainer).isChecked();
 
+      await click(`#${doraContainer.id} [data-test-ak-form-label]`);
+
+      assert.dom('[data-test-preference-checkbox]', doraContainer).isChecked();
+
       await click(`#${pcidssContainer.id} [data-test-ak-form-label]`);
 
       assert
@@ -332,6 +371,12 @@ module(
 
       assert
         .dom('[data-test-preference-checkbox]', samaContainer)
+        .isNotChecked();
+
+      await click(`#${doraContainer.id} [data-test-ak-form-label]`);
+
+      assert
+        .dom('[data-test-preference-checkbox]', doraContainer)
         .isNotChecked();
     });
 
@@ -362,6 +407,7 @@ module(
       const gdprContainer = find('[data-test-preference="GDPR"]');
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
+      const doraContainer = find('[data-test-preference="DORA"]');
 
       await click(`#${pcidssContainer.id} [data-test-ak-form-label]`);
 
@@ -425,6 +471,20 @@ module(
       assert
         .dom('[data-test-preference-checkbox]', samaContainer)
         [pref.show_sama ? 'isChecked' : 'isNotChecked']();
+
+      assert.strictEqual(
+        notify.errorMsg,
+        errorObj.report_preference.non_field_errors[0]
+      );
+
+      notify.errorMsg = null;
+
+      await click(`#${doraContainer.id} [data-test-ak-form-label]`);
+
+      // no change to state
+      assert
+        .dom('[data-test-preference-checkbox]', doraContainer)
+        [pref.show_dora ? 'isChecked' : 'isNotChecked']();
 
       assert.strictEqual(
         notify.errorMsg,

--- a/tests/integration/components/security/analysis-details-test.js
+++ b/tests/integration/components/security/analysis-details-test.js
@@ -101,6 +101,7 @@ module('Integration | Component | security/analysis-details', function (hooks) {
       ['v2/nistsp80053s', 'nistsp80053s', 'nistsp80053'],
       ['v2/nistsp800171s', 'nistsp800171s', 'nistsp800171'],
       ['v2/samas', 'samas', 'sama'],
+      ['v2/doras', 'doras', 'dora'],
     ].forEach(([urlParam, schemaKey, key, isJsonApi]) => {
       this.server.get(`/${urlParam}/:id`, (schema, req) => {
         const json = schema[schemaKey].find(`${req.params.id}`)?.toJSON();
@@ -730,6 +731,12 @@ module('Integration | Component | security/analysis-details', function (hooks) {
         'withSama',
         'sama',
         'Saudi Arabian Monetary Authority',
+        ['code', 'title'],
+      ],
+      [
+        'withDora',
+        'dora',
+        'Digital Operational Resilience Act',
         ['code', 'title'],
       ],
     ],

--- a/tests/unit/adapters/dora-test.js
+++ b/tests/unit/adapters/dora-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | dora', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let adapter = this.owner.lookup('adapter:dora');
+    assert.ok(adapter);
+  });
+});

--- a/tests/unit/models/dora-test.js
+++ b/tests/unit/models/dora-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | dora', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('dora', {});
+    assert.ok(model);
+  });
+});

--- a/translations/en.json
+++ b/translations/en.json
@@ -1909,6 +1909,8 @@
   "running": "Running",
   "sama": "SAMA",
   "samaExpansion": "Saudi Arabian Monetary Authority",
+  "dora": "DORA",
+  "doraExpansion": "Digital Operational Resilience Act",
   "samlAuth": "SAML Authentication",
   "samlDesc": "SAML-based single sign-on (SSO) gives users access to app through an identity provider (IdP) of your choice. Get set up with ADFS, G Suite, Auth0, OneLogin, or your custom SAML 2.0 solution.",
   "sast": "SAST",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1909,6 +1909,8 @@
   "running": "Running",
   "sama": "SAMA",
   "samaExpansion": "Saudi Arabian Monetary Authority",
+  "dora": "DORA",
+  "doraExpansion": "Digital Operational Resilience Act",
   "samlAuth": "SAML Authentication",
   "samlDesc": "SAML-based single sign-on (SSO) gives users access to app through an identity provider (IdP) of your choice. Get set up with ADFS, G Suite, Auth0, OneLogin, or your custom SAML 2.0 solution.",
   "sast": "SAST",


### PR DESCRIPTION
## PR Changes

- **DORA model & adapter** — Added `app/models/dora.ts` (code/title attributes, `hasMoreDetails: false`) and `app/adapters/dora.ts` (namespace_v2, `/v2/doras` endpoint). Unit tests for both.
- **Analysis model** — Added `dora` hasMany relationship to `app/models/analysis.ts` and `app/models/security/analysis.ts`.
- **Organisation preference / profile** — Added `show_dora` toggle to `app/models/organization-preference.ts` and `app/models/profile.ts`.
- **Regulatory preference UI** — Wired DORA into `regulatory-preference` (project settings) and `regulatory-preference-organization` (org settings), including `saveDora` task and translated labels (`this.intl.t('dora')`) for all six regulatories.
- **File-details & Knox-IQ** — DORA regulatory section added to `file-details/vulnerability-analysis-details` and `knox-iq/vulnerability-analysis-details`; `hasMoreDetails: false` (no expand/collapse UI).
- **Security analysis details** — DORA added to regulatory categories; full title "Digital Operational Resilience Act".
- **Translations** — Added `dora` and `doraExpansion` keys to `en.json` and `ja.json`.
- **Mirage** — `dora` factory, `withDora` and `withAllRegulatory` traits on analysis factories, `show_dora` on org-preference factory.
- **Integration tests** — DORA coverage added to four integration test files; `/v2/doras/:id` Mirage handlers added wherever `withAllRegulatory` analyses are rendered with a risky computed risk.