### PR TITLE
feat: added EU CRA compliance framework

### DIFF
--- a/app/adapters/eucra.ts
+++ b/app/adapters/eucra.ts
@@ -1,0 +1,11 @@
+import CommonDRFAdapter from './commondrf';
+
+export default class EucraAdapter extends CommonDRFAdapter {
+  namespace = this.namespace_v2;
+}
+
+declare module 'ember-data/types/registries/adapter' {
+  export default interface AdapterRegistry {
+    eucra: EucraAdapter;
+  }
+}

--- a/app/components/file-details/vulnerability-analysis-details/index.ts
+++ b/app/components/file-details/vulnerability-analysis-details/index.ts
@@ -20,6 +20,7 @@ import type Nistsp80053Model from 'irene/models/nistsp80053';
 import type Nistsp800171Model from 'irene/models/nistsp800171';
 import type SamaModel from 'irene/models/sama';
 import type DoraModel from 'irene/models/dora';
+import type EucraModel from 'irene/models/eucra';
 
 export interface FileDetailsVulnerabilityAnalysisDetailsSignature {
   Args: {
@@ -166,6 +167,14 @@ export default class FileDetailsVulnerabilityAnalysisDetailsComponent extends Co
         title: this.intl.t('doraExpansion'),
         contents: this.analysis.dora?.content as DoraModel[],
         hasContent: this.analysis.showDora && !isEmpty(this.analysis.dora),
+        hasMoreDetails: false,
+      },
+      {
+        key: 'eucra',
+        heading: this.intl.t('eucra'),
+        title: this.intl.t('eucraExpansion'),
+        contents: this.analysis.eucra?.content as EucraModel[],
+        hasContent: this.analysis.showEucra && !isEmpty(this.analysis.eucra),
         hasMoreDetails: false,
       },
     ];

--- a/app/components/knox-iq/vulnerability-analysis-details/index.ts
+++ b/app/components/knox-iq/vulnerability-analysis-details/index.ts
@@ -219,6 +219,14 @@ export default class KnoxIqVulnerabilityAnalysisDetailsComponent extends Compone
         hasContent: this.analysis.showDora && !isEmpty(this.analysis.dora),
         hasMoreDetails: false,
       },
+      {
+        key: 'eucra',
+        heading: this.intl.t('eucra'),
+        title: this.intl.t('eucraExpansion'),
+        contents: this.analysis.eucra,
+        hasContent: this.analysis.showEucra && !isEmpty(this.analysis.eucra),
+        hasMoreDetails: false,
+      },
     ];
   }
 

--- a/app/components/project-settings/analysis-settings/regulatory-preference/index.ts
+++ b/app/components/project-settings/analysis-settings/regulatory-preference/index.ts
@@ -89,6 +89,15 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
         isSaving: this.onSaveDora.isRunning,
         isOverriden: !this.profile?.reportPreference.show_dora?.is_inherited,
       },
+      {
+        label: this.intl.t('eucra'),
+        title: this.intl.t('eucraExpansion'),
+        value: this.profile?.reportPreference.show_eucra?.value,
+        toggleHandler: this.onSaveEucra,
+        resetHandler: this.onResetEucra,
+        isSaving: this.onSaveEucra.isRunning,
+        isOverriden: !this.profile?.reportPreference.show_eucra?.is_inherited,
+      },
     ];
   }
 
@@ -165,6 +174,10 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
     await this.savePreference.perform(event, 'dora');
   });
 
+  onSaveEucra = task(async (event: Event) => {
+    await this.savePreference.perform(event, 'eucra');
+  });
+
   onResetPcidss = task(async () => {
     await this.resetPreference.perform('pcidss');
   });
@@ -187,6 +200,10 @@ export default class ProjectSettingsAnalysisSettingsRegulatoryPreferenceComponen
 
   onResetDora = task(async () => {
     await this.resetPreference.perform('dora');
+  });
+
+  onResetEucra = task(async () => {
+    await this.resetPreference.perform('eucra');
   });
 }
 

--- a/app/components/regulatory-preference-organization/index.ts
+++ b/app/components/regulatory-preference-organization/index.ts
@@ -60,6 +60,12 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
         task: this.saveDora,
         title: this.intl.t('doraExpansion'),
       },
+      {
+        label: this.intl.t('eucra'),
+        checked: Boolean(this.orgPreference?.reportPreference?.show_eucra),
+        task: this.saveEucra,
+        title: this.intl.t('eucraExpansion'),
+      },
     ];
   }
 
@@ -100,6 +106,10 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
     await this.saveReportPreference.perform('show_dora', event);
   });
 
+  saveEucra = task(async (event) => {
+    await this.saveReportPreference.perform('show_eucra', event);
+  });
+
   saveReportPreference = task(
     async (
       regulator:
@@ -108,7 +118,8 @@ export default class RegulatoryPreferenceOrganizationComponent extends Component
         | 'show_gdpr'
         | 'show_nist'
         | 'show_sama'
-        | 'show_dora',
+        | 'show_dora'
+        | 'show_eucra',
       event
     ) => {
       const preference = this.orgPreference as OrganizationPreferenceModel;

--- a/app/components/security/analysis-details/index.ts
+++ b/app/components/security/analysis-details/index.ts
@@ -292,6 +292,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       nistsp80053,
       sama,
       dora,
+      eucra,
     ] = await Promise.all([
       details?.owasp,
       details?.owaspmobile2024,
@@ -308,6 +309,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       details?.nistsp80053,
       details?.sama,
       details?.dora,
+      details?.eucra,
     ]);
 
     // Normalise status: Ember Data may hand back a boxed object pre-save.
@@ -344,6 +346,7 @@ export default class SecurityAnalysisDetailsComponent extends Component<Security
       nistsp800171: nistsp800171?.map((a) => a.id),
       sama: sama?.map((a) => a.id),
       dora: dora?.map((a) => a.id),
+      eucra: eucra?.map((a) => a.id),
       overridden_risk: overriddenRisk,
       overridden_risk_comment: details?.overriddenRiskComment,
       overridden_risk_to_profile: details?.overriddenRiskToProfile,

--- a/app/components/security/analysis-details/regulatory-categories/index.ts
+++ b/app/components/security/analysis-details/regulatory-categories/index.ts
@@ -26,6 +26,7 @@ import type IntlService from 'ember-intl/services/intl';
 import type DoraModel from 'irene/models/dora';
 import type SamaModel from 'irene/models/sama';
 import type Pcidss4Model from 'irene/models/pcidss4';
+import type EucraModel from 'irene/models/eucra';
 
 type RegulatoryCategoryOptionKeys =
   | 'owasp'
@@ -42,7 +43,8 @@ type RegulatoryCategoryOptionKeys =
   | 'nistsp800171'
   | 'nistsp80053'
   | 'sama'
-  | 'dora';
+  | 'dora'
+  | 'eucra';
 
 type RegulatoryCategoryModels =
   | OwaspModel
@@ -59,7 +61,8 @@ type RegulatoryCategoryModels =
   | Nistsp80053Model
   | Nistsp800171Model
   | SamaModel
-  | DoraModel;
+  | DoraModel
+  | EucraModel;
 
 type RegulatoryDataModel<T> = ArrayProxy<T> | null;
 
@@ -91,6 +94,7 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
   @tracked nistsp800171sData: RegulatoryDataModel<Nistsp800171Model> = null;
   @tracked samaData: RegulatoryDataModel<SamaModel> = null;
   @tracked doraData: RegulatoryDataModel<DoraModel> = null;
+  @tracked eucraData: RegulatoryDataModel<EucraModel> = null;
 
   risks = ENUMS.RISK.CHOICES;
 
@@ -177,6 +181,10 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
 
   get doras() {
     return this.doraData?.slice() || [];
+  }
+
+  get eucras() {
+    return this.eucraData?.slice() || [];
   }
 
   get regulatoryCategories() {
@@ -318,6 +326,15 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
         options: this.doras,
         onChange: this.onCategorySelect('dora'),
       },
+      {
+        key: 'eucra',
+        title: 'EU Cyber Resilience Act',
+        placeholder: 'Select EU CRA',
+        labelKeys: ['code', 'title'],
+        selected: this.analysis?.eucra ?? [],
+        options: this.eucras,
+        onChange: this.onCategorySelect('eucra'),
+      },
     ] as Array<{
       key: string;
       title: string;
@@ -386,6 +403,8 @@ export default class SecurityAnalysisDetailsRegulatoryCategoriesComponent extend
       this.pcidss4sData = await this.store.findAll('pcidss4');
 
       this.doraData = await this.store.findAll('dora');
+
+      this.eucraData = await this.store.findAll('eucra');
     } catch (error) {
       this.notifications.error(parseError(error, this.tPleaseTryAgain));
     }

--- a/app/components/security/analysis-list/table/action/index.ts
+++ b/app/components/security/analysis-list/table/action/index.ts
@@ -100,6 +100,7 @@ export default class SecurityAnalysisListTableActionComponent extends Component<
           ),
           sama: (await this.analysis.sama).map((a) => a.get('id')),
           dora: (await this.analysis.dora).map((a) => a.get('id')),
+          eucra: (await this.analysis.eucra).map((a) => a.get('id')),
           findings: this.analysis.findings,
           overridden_risk: this.analysis.overriddenRisk || 'None',
           overridden_risk_comment: this.analysis.overriddenRiskComment || '',

--- a/app/models/analysis.ts
+++ b/app/models/analysis.ts
@@ -25,6 +25,7 @@ import type Nistsp80053Model from './nistsp80053';
 import type SamaModel from './sama';
 import type Pcidss4Model from './pcidss4';
 import type DoraModel from './dora';
+import type EucraModel from './eucra';
 import type { KnoxiqValidatedFindingExploitability } from './knoxiq-validated-finding';
 
 irregular('asvs', 'asvses');
@@ -145,6 +146,9 @@ export default class AnalysisModel extends Model {
 
   @hasMany('dora', { async: true, inverse: null })
   declare dora: AsyncHasMany<DoraModel>;
+
+  @hasMany('eucra', { async: true, inverse: null })
+  declare eucra: AsyncHasMany<EucraModel>;
 
   @belongsTo('vulnerability', { async: true, inverse: null })
   declare vulnerability: AsyncBelongsTo<VulnerabilityModel>;
@@ -301,6 +305,10 @@ export default class AnalysisModel extends Model {
 
   get showDora() {
     return this.file.get('profile')?.get('reportPreference')?.show_dora?.value;
+  }
+
+  get showEucra() {
+    return this.file.get('profile')?.get('reportPreference')?.show_eucra?.value;
   }
 
   get vulnerabilityTypes() {

--- a/app/models/eucra.ts
+++ b/app/models/eucra.ts
@@ -1,0 +1,15 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class EucraModel extends Model {
+  @attr('string')
+  declare code: string;
+
+  @attr('string')
+  declare title: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+  export default interface ModelRegistry {
+    eucra: EucraModel;
+  }
+}

--- a/app/models/organization-preference.ts
+++ b/app/models/organization-preference.ts
@@ -7,6 +7,7 @@ interface ReportPreferenceData {
   show_nist: boolean;
   show_sama: boolean;
   show_dora: boolean;
+  show_eucra: boolean;
 }
 
 export default class OrganizationPreferenceModel extends Model {

--- a/app/models/profile.ts
+++ b/app/models/profile.ts
@@ -18,6 +18,7 @@ export interface ProfileReportPreference {
   show_nist: ValueObject;
   show_sama: ValueObject;
   show_dora: ValueObject;
+  show_eucra: ValueObject;
 }
 
 export type SaveReportPreferenceData = Pick<
@@ -35,7 +36,8 @@ export type ProfileRegulatoryReportPreference =
   | 'gdpr'
   | 'nist'
   | 'sama'
-  | 'dora';
+  | 'dora'
+  | 'eucra';
 
 type ProfileAdapterName = 'profile';
 

--- a/app/models/security/analysis.ts
+++ b/app/models/security/analysis.ts
@@ -25,6 +25,7 @@ import type Nistsp80053Model from '../nistsp80053';
 import type Nistsp800171Model from '../nistsp800171';
 import type SamaModel from '../sama';
 import type Pcidss4Model from '../pcidss4';
+import type EucraModel from '../eucra';
 
 irregular('asvs', 'asvses');
 
@@ -154,6 +155,9 @@ export default class SecurityAnalysisModel extends Model {
 
   @hasMany('dora', { async: true, inverse: null })
   declare dora: AsyncHasMany<DoraModel>;
+
+  @hasMany('eucra', { async: true, inverse: null })
+  declare eucra: AsyncHasMany<EucraModel>;
 
   @hasMany('security/attachment', { async: true, inverse: null })
   declare attachments: AsyncHasMany<SecurityAttachmentModel>;

--- a/mirage/factories/analysis.ts
+++ b/mirage/factories/analysis.ts
@@ -175,6 +175,14 @@ export default Factory.extend({
     },
   }),
 
+  withEucra: trait({
+    afterCreate(model: ModelInstance, server: Server) {
+      model.update({
+        eucra: server.createList('eucra', 2).map((it) => it.id),
+      });
+    },
+  }),
+
   withAllRegulatory: trait({
     afterCreate(model: ModelInstance, server: Server) {
       model.update({
@@ -194,6 +202,7 @@ export default Factory.extend({
         nistsp800171: server.createList('nistsp800171', 2).map((it) => it.id),
         sama: server.createList('sama', 2).map((it) => it.id),
         dora: server.createList('dora', 2).map((it) => it.id),
+        eucra: server.createList('eucra', 2).map((it) => it.id),
       });
     },
   }),

--- a/mirage/factories/eucra.ts
+++ b/mirage/factories/eucra.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+export default Factory.extend({
+  code(i) {
+    return `cra_${i}`;
+  },
+
+  title() {
+    return faker.lorem.sentence();
+  },
+});

--- a/mirage/factories/organization-preference.ts
+++ b/mirage/factories/organization-preference.ts
@@ -9,5 +9,6 @@ export default Factory.extend({
     show_nist: faker.datatype.boolean(),
     show_sama: faker.datatype.boolean(),
     show_dora: faker.datatype.boolean(),
+    show_eucra: faker.datatype.boolean(),
   }),
 });

--- a/mirage/factories/security/analysis.js
+++ b/mirage/factories/security/analysis.js
@@ -242,6 +242,14 @@ export default Factory.extend({
     },
   }),
 
+  withEucra: trait({
+    afterCreate(model, server) {
+      model.update({
+        eucra: server.createList('eucra', 2).map((it) => it.id),
+      });
+    },
+  }),
+
   withAllRegulatory: trait({
     afterCreate(model, server) {
       model.update({
@@ -261,6 +269,7 @@ export default Factory.extend({
         nistsp800171: server.createList('nistsp800171', 2).map((it) => it.id),
         sama: server.createList('sama', 2).map((it) => it.id),
         dora: server.createList('dora', 2).map((it) => it.id),
+        eucra: server.createList('eucra', 2).map((it) => it.id),
       });
     },
   }),

--- a/tests/integration/components/file-details/vulnerability-analysis-details/index-test.js
+++ b/tests/integration/components/file-details/vulnerability-analysis-details/index-test.js
@@ -259,6 +259,10 @@ module(
         schema.doras.find(`${req.params.id}`)?.toJSON()
       );
 
+      this.server.get('/v2/eucras/:id', (schema, req) =>
+        schema.eucras.find(`${req.params.id}`)?.toJSON()
+      );
+
       await render(
         hbs`<FileDetails::VulnerabilityAnalysisDetails @analysis={{this.analysis}} />`
       );
@@ -1173,6 +1177,10 @@ module(
           schema.doras.find(`${req.params.id}`)?.toJSON()
         );
 
+        this.server.get('/v2/eucras/:id', (schema, req) =>
+          schema.eucras.find(`${req.params.id}`)?.toJSON()
+        );
+
         await render(
           hbs`<FileDetails::VulnerabilityAnalysisDetails @analysis={{this.analysis}} />`
         );
@@ -1305,6 +1313,10 @@ module(
 
       this.server.get('/v2/doras/:id', (schema, req) =>
         schema.doras.find(`${req.params.id}`)?.toJSON()
+      );
+
+      this.server.get('/v2/eucras/:id', (schema, req) =>
+        schema.eucras.find(`${req.params.id}`)?.toJSON()
       );
 
       await render(
@@ -1451,6 +1463,7 @@ module(
           null,
         ],
         ['withDora', 'v2/doras', 'doras', 'dora', null],
+        ['withEucra', 'v2/eucras', 'eucras', 'eucra', null],
       ],
       async function (
         assert,
@@ -1525,6 +1538,10 @@ module(
               },
               show_dora: {
                 value: modelKey === 'dora',
+                is_inherited: false,
+              },
+              show_eucra: {
+                value: modelKey === 'eucra',
                 is_inherited: false,
               },
             },
@@ -1608,6 +1625,8 @@ module(
         ['sama'],
         ['dora', []],
         ['dora'],
+        ['eucra', []],
+        ['eucra'],
       ],
       async function (assert, [modelKey, modelValue]) {
         const vulnerability = this.store.push(
@@ -1662,6 +1681,7 @@ module(
           ['v2/nistsp800171s', 'nistsp800171s', 'nistsp800171'],
           ['v2/samas', 'samas', 'sama'],
           ['v2/doras', 'doras', 'dora'],
+          ['v2/eucras', 'eucras', 'eucra'],
         ].forEach(([urlParam, schemaKey, key, isJsonApi]) => {
           if (key !== modelKey) {
             this.server.get(`/${urlParam}/:id`, (schema, req) => {

--- a/tests/integration/components/project-settings/analysis-settings/regulatory-preference-test.js
+++ b/tests/integration/components/project-settings/analysis-settings/regulatory-preference-test.js
@@ -145,6 +145,7 @@ module(
         t('nist'),
         t('sama'),
         t('dora'),
+        t('eucra'),
       ];
 
       optionalRegulatoriesLabels.map((regLabel) =>
@@ -180,6 +181,10 @@ module(
             is_inherited: false,
           },
           show_dora: {
+            value: false,
+            is_inherited: false,
+          },
+          show_eucra: {
             value: false,
             is_inherited: false,
           },
@@ -279,6 +284,21 @@ module(
         return profile.report_preference.show_dora;
       });
 
+      this.server.put('profiles/:id/show_eucra', (schema, request) => {
+        const body = JSON.parse(request.requestBody);
+
+        const profile = schema['profiles'].find(request.params.id);
+
+        profile.report_preference.show_eucra = {
+          value: body.value,
+          is_inherited: false,
+        };
+
+        profile.save();
+
+        return profile.report_preference.show_eucra;
+      });
+
       await render(
         hbs`<ProjectSettings::AnalysisSettings::RegulatoryPreference @project={{this.project}}/>`
       );
@@ -355,6 +375,19 @@ module(
       await click(doraInput);
 
       assert.strictEqual(doraInput.checked, !doraInitialValue);
+
+      const eucra = this.element.querySelector(
+        `[data-test-projectSetting-analysisSettings-regulatoryPreferences="${t('eucra')}"]`
+      );
+
+      const eucraInitialValue = profile.report_preference.show_eucra.value;
+      const eucraInput = eucra.querySelector('[data-test-input]');
+
+      assert.strictEqual(eucraInput.checked, eucraInitialValue);
+
+      await click(eucraInput);
+
+      assert.strictEqual(eucraInput.checked, !eucraInitialValue);
     });
 
     test('it does not toggle preference value on error', async function (assert) {
@@ -381,6 +414,10 @@ module(
             is_inherited: false,
           },
           show_dora: {
+            value: false,
+            is_inherited: false,
+          },
+          show_eucra: {
             value: false,
             is_inherited: false,
           },
@@ -421,6 +458,10 @@ module(
       });
 
       this.server.put('profiles/:id/show_dora', () => {
+        return new Response(400, {}, { value: ['Must be a valid boolean.'] });
+      });
+
+      this.server.put('profiles/:id/show_eucra', () => {
         return new Response(400, {}, { value: ['Must be a valid boolean.'] });
       });
 
@@ -499,6 +540,19 @@ module(
       await click(doraInput);
 
       assert.strictEqual(doraInput.checked, doraInitialValue);
+
+      const eucra = this.element.querySelector(
+        `[data-test-projectSetting-analysisSettings-regulatoryPreferences="${t('eucra')}"]`
+      );
+
+      const eucraInitialValue = profile.report_preference.show_eucra.value;
+      const eucraInput = eucra.querySelector('[data-test-input]');
+
+      assert.strictEqual(eucraInput.checked, eucraInitialValue);
+
+      await click(eucraInput);
+
+      assert.strictEqual(eucraInput.checked, eucraInitialValue);
     });
 
     test('it displays overridden state with reset button if a preference is updated', async function (assert) {

--- a/tests/integration/components/regulatory-preference-organization-test.js
+++ b/tests/integration/components/regulatory-preference-organization-test.js
@@ -87,6 +87,13 @@ module(
       assert
         .dom('[data-test-ak-form-label]', find('[data-test-preference="DORA"]'))
         .hasText('DORA');
+
+      assert
+        .dom(
+          '[data-test-ak-form-label]',
+          find('[data-test-preference="EU CRA"]')
+        )
+        .hasText('EU CRA');
     });
 
     test('it renders regulatory list tooltip', async function (assert) {
@@ -102,6 +109,7 @@ module(
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
       const doraContainer = find('[data-test-preference="DORA"]');
+      const eucraContainer = find('[data-test-preference="EU CRA"]');
 
       // pci-dss
       await triggerEvent(
@@ -194,6 +202,21 @@ module(
       );
 
       assert.dom('[data-test-ak-tooltip-content]').doesNotExist();
+
+      // eucra
+      await triggerEvent(
+        `#${eucraContainer.id} [data-test-ak-tooltip-root]`,
+        'mouseenter'
+      );
+
+      assert.dom('[data-test-ak-tooltip-content]').hasText(t('eucraExpansion'));
+
+      await triggerEvent(
+        `#${eucraContainer.id} [data-test-ak-tooltip-root]`,
+        'mouseleave'
+      );
+
+      assert.dom('[data-test-ak-tooltip-content]').doesNotExist();
     });
 
     test('it renders regulatory inclusion status based on organization preference', async function (assert) {
@@ -205,6 +228,7 @@ module(
         json.report_preference.show_nist = true;
         json.report_preference.show_sama = true;
         json.report_preference.show_dora = false;
+        json.report_preference.show_eucra = false;
 
         return json;
       });
@@ -252,6 +276,13 @@ module(
           find('[data-test-preference="DORA"]')
         )
         .isNotChecked();
+
+      assert
+        .dom(
+          '[data-test-preference-checkbox]',
+          find('[data-test-preference="EU CRA"]')
+        )
+        .isNotChecked();
     });
 
     test('it toggles regulatory preference on label click', async function (assert) {
@@ -263,6 +294,7 @@ module(
         json.report_preference.show_nist = false;
         json.report_preference.show_sama = false;
         json.report_preference.show_dora = false;
+        json.report_preference.show_eucra = false;
 
         return json;
       });
@@ -287,6 +319,7 @@ module(
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
       const doraContainer = find('[data-test-preference="DORA"]');
+      const eucraContainer = find('[data-test-preference="EU CRA"]');
 
       assert
         .dom('[data-test-preference-checkbox]', pcidssContainer)
@@ -315,6 +348,11 @@ module(
 
       assert
         .dom('[data-test-preference-checkbox]', doraContainer)
+        .isNotDisabled()
+        .isNotChecked();
+
+      assert
+        .dom('[data-test-preference-checkbox]', eucraContainer)
         .isNotDisabled()
         .isNotChecked();
 
@@ -344,6 +382,10 @@ module(
 
       assert.dom('[data-test-preference-checkbox]', doraContainer).isChecked();
 
+      await click(`#${eucraContainer.id} [data-test-ak-form-label]`);
+
+      assert.dom('[data-test-preference-checkbox]', eucraContainer).isChecked();
+
       await click(`#${pcidssContainer.id} [data-test-ak-form-label]`);
 
       assert
@@ -378,6 +420,12 @@ module(
 
       assert
         .dom('[data-test-preference-checkbox]', doraContainer)
+        .isNotChecked();
+
+      await click(`#${eucraContainer.id} [data-test-ak-form-label]`);
+
+      assert
+        .dom('[data-test-preference-checkbox]', eucraContainer)
         .isNotChecked();
     });
 
@@ -409,6 +457,7 @@ module(
       const nistContainer = find('[data-test-preference="NIST"]');
       const samaContainer = find('[data-test-preference="SAMA"]');
       const doraContainer = find('[data-test-preference="DORA"]');
+      const eucraContainer = find('[data-test-preference="EU CRA"]');
 
       await click(`#${pcidssContainer.id} [data-test-ak-form-label]`);
 
@@ -486,6 +535,20 @@ module(
       assert
         .dom('[data-test-preference-checkbox]', doraContainer)
         [pref.show_dora ? 'isChecked' : 'isNotChecked']();
+
+      assert.strictEqual(
+        notify.errorMsg,
+        errorObj.report_preference.non_field_errors[0]
+      );
+
+      notify.errorMsg = null;
+
+      await click(`#${eucraContainer.id} [data-test-ak-form-label]`);
+
+      // no change to state
+      assert
+        .dom('[data-test-preference-checkbox]', eucraContainer)
+        [pref.show_eucra ? 'isChecked' : 'isNotChecked']();
 
       assert.strictEqual(
         notify.errorMsg,

--- a/tests/integration/components/security/analysis-details-test.js
+++ b/tests/integration/components/security/analysis-details-test.js
@@ -102,6 +102,7 @@ module('Integration | Component | security/analysis-details', function (hooks) {
       ['v2/nistsp800171s', 'nistsp800171s', 'nistsp800171'],
       ['v2/samas', 'samas', 'sama'],
       ['v2/doras', 'doras', 'dora'],
+      ['v2/eucras', 'eucras', 'eucra'],
     ].forEach(([urlParam, schemaKey, key, isJsonApi]) => {
       this.server.get(`/${urlParam}/:id`, (schema, req) => {
         const json = schema[schemaKey].find(`${req.params.id}`)?.toJSON();
@@ -739,6 +740,7 @@ module('Integration | Component | security/analysis-details', function (hooks) {
         'Digital Operational Resilience Act',
         ['code', 'title'],
       ],
+      ['withEucra', 'eucra', 'EU Cyber Resilience Act', ['code', 'title']],
     ],
     async function (
       assert,

--- a/tests/unit/adapters/eucra-test.js
+++ b/tests/unit/adapters/eucra-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | eucra', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    const adapter = this.owner.lookup('adapter:eucra');
+    assert.ok(adapter);
+  });
+});

--- a/tests/unit/models/eucra-test.js
+++ b/tests/unit/models/eucra-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | eucra', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('eucra', {});
+    assert.ok(model);
+  });
+});

--- a/translations/en.json
+++ b/translations/en.json
@@ -1964,6 +1964,8 @@
   "samaExpansion": "Saudi Arabian Monetary Authority",
   "dora": "DORA",
   "doraExpansion": "Digital Operational Resilience Act",
+  "eucra": "EU CRA",
+  "eucraExpansion": "EU Cyber Resilience Act",
   "samlAuth": "SAML Authentication",
   "samlDesc": "SAML-based single sign-on (SSO) gives users access to app through an identity provider (IdP) of your choice. Get set up with ADFS, G Suite, Auth0, OneLogin, or your custom SAML 2.0 solution.",
   "sast": "SAST",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1964,6 +1964,8 @@
   "samaExpansion": "Saudi Arabian Monetary Authority",
   "dora": "DORA",
   "doraExpansion": "Digital Operational Resilience Act",
+  "eucra": "EU CRA",
+  "eucraExpansion": "EU Cyber Resilience Act",
   "samlAuth": "SAML Authentication",
   "samlDesc": "SAML-based single sign-on (SSO) gives users access to app through an identity provider (IdP) of your choice. Get set up with ADFS, G Suite, Auth0, OneLogin, or your custom SAML 2.0 solution.",
   "sast": "SAST",


### PR DESCRIPTION
## PR Changes

- **EU CRA model & adapter** — Added `app/models/eucra.ts` (code/title attributes, `hasMoreDetails: false`) and `app/adapters/eucra.ts` (namespace_v2, `/v2/eucras` endpoint). Unit tests for both.
- **Analysis model** — Added `eucra` hasMany relationship to `app/models/analysis.ts` and `app/models/security/analysis.ts`.
- **Organisation preference / profile** — Added `show_eucra` toggle to `app/models/organization-preference.ts` and `app/models/profile.ts`.
- **Regulatory preference UI** — Wired EU CRA into `regulatory-preference` (project settings) and `regulatory-preference-organization` (org settings), including `saveEucra` task and translated labels (`this.intl.t('eucra')`) for all regulatories.
- **File-details & Knox-IQ** — EU CRA regulatory section added to `file-details/vulnerability-analysis-details` and `knox-iq/vulnerability-analysis-details`; `hasMoreDetails: false` (no expand/collapse UI).
- **Security analysis details** — EU CRA added to regulatory categories; full title "EU Cyber Resilience Act".
- **Translations** — Added `eucra` and `eucraExpansion` keys to `en.json` and `ja.json`.
- **Mirage** — `eucra` factory, `withEucra` and `withAllRegulatory` traits on analysis factories, `show_eucra` on org-preference factory.
- **Integration tests** — EU CRA coverage added to four integration test files; `/v2/eucras/:id` Mirage handlers added wherever `withAllRegulatory` analyses are rendered with a risky computed risk.