### PR TITLE
feat(cyod): account settings CYOD page and device registration

### DIFF
--- a/app/components/account-settings/cyod-settings/index.hbs
+++ b/app/components/account-settings/cyod-settings/index.hbs
@@ -1,0 +1,242 @@
+{{#if this.visible}}
+  <AkStack
+    class='p-3'
+    @direction='column'
+    local-class='cyod-settings-container'
+    data-test-cyodSettings
+    ...attributes
+  >
+    <AkStack @width='full' @direction='column' @spacing='2'>
+      <AkTypography @variant='h5' data-test-cyodSettings-title>
+        {{t 'cyod.registration.title'}}
+      </AkTypography>
+
+      {{#if this.isRegistrationEnabled}}
+        <AkStack
+          @width='full'
+          @alignItems='flex-start'
+          @justifyContent='space-between'
+          @spacing='2'
+        >
+          <AkStack @direction='column' @spacing='1'>
+            <AkTypography
+              @variant='subtitle1'
+              data-test-cyodSettings-registerTitle
+            >
+              {{t 'cyod.settings.deviceRegistration'}}
+            </AkTypography>
+
+            <AkTypography @variant='body2' @color='textSecondary'>
+              {{t 'cyod.settings.deviceRegistrationDesc'}}
+            </AkTypography>
+          </AkStack>
+
+          <AkButton
+            data-test-cyodSettings-registerBtn
+            @variant='filled'
+            {{on 'click' this.handleOpen}}
+          >
+            {{t 'cyod.settings.registerADevice'}}
+          </AkButton>
+        </AkStack>
+
+        <AkDivider @color='dark' />
+
+        <Cyod::DeviceTable
+          @heading={{t 'cyod.settings.connectedDevice'}}
+          @subheading={{t 'cyod.settings.connectedDeviceDesc'}}
+          @emptyHint={{t 'cyod.settings.emptyHint' htmlSafe=true}}
+          @onlyConnected={{true}}
+        />
+      {{else}}
+        <AkStack
+          @width='full'
+          local-class='disabled-state'
+          data-test-cyodSettings-disabled
+        >
+          <AkStack
+            @direction='column'
+            @alignItems='center'
+            @justifyContent='center'
+            @spacing='2'
+            @width='full'
+            class='py-7 px-4'
+          >
+            <AkSvg::ToggleAutomatedDast data-test-cyodSettings-disabledSvg />
+
+            <AkStack @direction='column' @alignItems='center' @spacing='0.5'>
+              <AkTypography
+                @variant='body1'
+                @tag='h5'
+                @fontWeight='medium'
+                data-test-cyodSettings-disabledTitle
+              >
+                {{t 'cyod.settings.turnOnTitle'}}
+              </AkTypography>
+
+              <AkTypography
+                local-class='disabled-desc'
+                @variant='body2'
+                @align='center'
+                data-test-cyodSettings-disabledDesc
+              >
+                {{if
+                  this.isOwner
+                  (t 'cyod.settings.turnOnDescOwner')
+                  (t 'cyod.settings.turnOnDesc')
+                }}
+              </AkTypography>
+            </AkStack>
+          </AkStack>
+        </AkStack>
+      {{/if}}
+    </AkStack>
+  </AkStack>
+
+  <AkDrawer
+    @open={{this.showDrawer}}
+    @onClose={{this.handleClose}}
+    @anchor='right'
+    as |dr|
+  >
+    <div
+      data-test-cyodSettings-drawer
+      local-class='register-drawer'
+      {{style height='100%'}}
+    >
+      <AkAppbar @justifyContent='space-between' as |ab|>
+        <AkTypography
+          data-test-cyodSettings-drawerTitle
+          @variant='h5'
+          @color='inherit'
+        >
+          {{t 'cyod.settings.registerADevice'}}
+        </AkTypography>
+
+        <AkIconButton
+          data-test-cyodSettings-drawerCloseBtn
+          class={{ab.classes.defaultIconBtn}}
+          {{on 'click' dr.closeHandler}}
+        >
+          <AkIcon @iconName='close' />
+        </AkIconButton>
+      </AkAppbar>
+
+      <AkStack @direction='column' @spacing='3' class='p-3'>
+        <AkStack @direction='column' @spacing='1'>
+          <AkTypography @variant='subtitle1'>
+            {{t 'cyod.settings.yourRegisteredDevices'}}
+          </AkTypography>
+
+          <AkTypography @variant='body2' @color='textSecondary'>
+            {{t 'cyod.settings.stepsIntro'}}
+          </AkTypography>
+        </AkStack>
+
+        <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+          <div local-class='step-num' aria-hidden='true'>1</div>
+
+          <AkStack @direction='column' @spacing='1.5'>
+            <AkTypography @variant='body1' @fontWeight='medium'>
+              {{t 'cyod.settings.stepCertificate'}}
+            </AkTypography>
+
+            <AkTypography @variant='body1' @color='textSecondary'>
+              <strong data-test-cyodSettings-noteLabel>{{t
+                  'cyod.settings.noteLabel'
+                }}</strong>
+              {{t 'cyod.settings.stepCertificateNote'}}
+            </AkTypography>
+          </AkStack>
+        </AkStack>
+
+        <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+          <div local-class='step-num' aria-hidden='true'>2</div>
+
+          <AkStack @direction='column' @spacing='1.5'>
+            <AkStack @direction='column' @spacing='2' @alignItems='flex-start'>
+              <AkTypography @variant='body1' @fontWeight='medium'>
+                {{t 'cyod.settings.stepDownload'}}
+              </AkTypography>
+
+              <AkButton
+                data-test-cyodSettings-downloadBtn
+                @tag='a'
+                href={{this.mercerDownloadUrl}}
+                target='_blank'
+                rel='noopener noreferrer'
+                @variant='filled'
+              >
+                <AkIcon @iconName='download' @size='small' />
+
+                <span class='ml-1'>{{t 'cyod.settings.downloadMercer'}}</span>
+              </AkButton>
+            </AkStack>
+
+            <AkTypography @variant='body1' @color='textSecondary'>
+              <strong data-test-cyodSettings-noteLabel>{{t
+                  'cyod.settings.noteLabel'
+                }}</strong>
+              {{t 'cyod.settings.stepDownloadNote'}}
+            </AkTypography>
+          </AkStack>
+        </AkStack>
+
+        <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+          <div local-class='step-num' aria-hidden='true'>3</div>
+
+          <AkStack @direction='column' @spacing='1.5' @width='full'>
+            <AkTypography @variant='body1' @fontWeight='medium'>
+              {{t 'cyod.settings.stepSignIn'}}
+            </AkTypography>
+
+            <AkStack
+              local-class='url-field'
+              @spacing='1'
+              @alignItems='center'
+              @justifyContent='space-between'
+            >
+              <AkTypography
+                data-test-cyodSettings-serverUrl
+                local-class='url-value'
+              >
+                {{this.serverUrl}}
+              </AkTypography>
+
+              <AkClipboard @onSuccess={{this.handleCopySuccess}} as |ac|>
+                <AkIconButton
+                  data-test-cyodSettings-copyBtn
+                  data-clipboard-text={{this.serverUrl}}
+                  id={{ac.triggerId}}
+                  @size='small'
+                >
+                  <AkIcon @iconName='content-copy' @color='primary' />
+                </AkIconButton>
+              </AkClipboard>
+            </AkStack>
+
+            <AkTypography local-class='token-hint' @color='textSecondary'>
+              {{t 'cyod.settings.stepSignInNote'}}
+            </AkTypography>
+          </AkStack>
+        </AkStack>
+
+        <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+          <div local-class='step-num' aria-hidden='true'>4</div>
+
+          <AkTypography @variant='body1' @fontWeight='medium'>
+            {{t 'cyod.settings.stepRegister'}}
+          </AkTypography>
+        </AkStack>
+
+        <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+          <div local-class='step-num' aria-hidden='true'>5</div>
+
+          <AkTypography @variant='body1' @fontWeight='medium'>
+            {{t 'cyod.settings.stepRun'}}
+          </AkTypography>
+        </AkStack>
+      </AkStack>
+    </div>
+  </AkDrawer>
+{{/if}}

--- a/app/components/account-settings/cyod-settings/index.scss
+++ b/app/components/account-settings/cyod-settings/index.scss
@@ -1,0 +1,55 @@
+.cyod-settings-container {
+  width: 100%;
+  background: var(--account-settings-cyod-settings-background);
+}
+
+.register-drawer {
+  width: 500px;
+  overflow-y: auto;
+}
+
+.disabled-state {
+  box-sizing: border-box;
+  border: 1px solid
+    var(--account-settings-cyod-settings-disabled-state-border-color);
+  border-radius: var(
+    --account-settings-cyod-settings-disabled-state-border-radius
+  );
+}
+
+.disabled-desc {
+  max-width: 345px;
+}
+
+.step-num {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: var(--account-settings-cyod-settings-step-num-border-radius);
+  background: var(--account-settings-cyod-settings-step-num-background);
+  color: var(--account-settings-cyod-settings-step-num-color);
+  font-size: 12px;
+  font-weight: var(--account-settings-cyod-settings-step-num-font-weight);
+  line-height: 1;
+}
+
+.url-field {
+  width: 100%;
+  padding: 0.28571em 0.28571em 0.28571em 0.85714em;
+  border: 1px solid var(--account-settings-cyod-settings-url-field-border-color);
+  border-radius: var(--account-settings-cyod-settings-url-field-border-radius);
+  background: var(--account-settings-cyod-settings-url-field-background);
+}
+
+.url-value.url-value {
+  font-family: var(--account-settings-cyod-settings-url-value-font-family);
+  font-size: 0.857rem; // 12px
+  word-break: break-all;
+}
+
+.token-hint.token-hint {
+  font-size: 0.786rem; // 11px
+}

--- a/app/components/account-settings/cyod-settings/index.ts
+++ b/app/components/account-settings/cyod-settings/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Account Settings → CYOD Settings (all user roles).
+ *
+ * Where an individual member enrols their own CYOD device and sees it once it is
+ * connected. Registration happens on the member's own machine via the Mercer
+ * desktop app (sign in with a Personal Token → register on the Devices tab →
+ * start the proxy on the Run tab); the dashboard only explains the steps and
+ * shows the resulting device.
+ *
+ * The org-wide view and the owner's kill-switch live in Organization Settings
+ * (`Organization::DeviceRegistration`).
+ */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import type IntlService from 'ember-intl/services/intl';
+
+import ENV from 'irene/config/environment';
+import type MeService from 'irene/services/me';
+import type OrganizationService from 'irene/services/organization';
+
+export interface AccountSettingsCyodSettingsSignature {
+  Element: HTMLDivElement;
+}
+
+export default class AccountSettingsCyodSettingsComponent extends Component<AccountSettingsCyodSettingsSignature> {
+  @service declare intl: IntlService;
+  @service declare organization: OrganizationService;
+  @service declare me: MeService;
+  @service('notifications') declare notify: NotificationService;
+
+  @tracked showDrawer = false;
+
+  // The tab is hidden without the entitlement, but the route is always
+  // registered — guard the panel too so a direct URL doesn't surface CYOD UI to
+  // an org that cannot use it.
+  get visible() {
+    return this.organization.isCyodEnabled;
+  }
+
+  get isRegistrationEnabled() {
+    return this.organization.isCyodRegistrationEnabled;
+  }
+
+  // The switch lives in Organization Settings and only the owner can flip it, so
+  // the owner gets sent there while everyone else is told who to ask.
+  get isOwner() {
+    return !!this.me.org?.is_owner;
+  }
+
+  // The mycroft API host to enter on the Mercer app's Login screen — correct for
+  // both SaaS and on-prem installs. Falls back to the current origin.
+  get serverUrl() {
+    return ENV.host || window.location.origin;
+  }
+
+  // Where the "Download Mercer" button points. Configured per deployment via
+  // IRENE_MERCER_DOWNLOAD_URL; see config/environment.js for the fallback.
+  get mercerDownloadUrl() {
+    return ENV.mercerDownloadUrl;
+  }
+
+  @action
+  handleOpen() {
+    this.showDrawer = true;
+  }
+
+  @action
+  handleClose() {
+    this.showDrawer = false;
+  }
+
+  @action
+  handleCopySuccess() {
+    this.notify.success(this.intl.t('copiedToClipboard'));
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'AccountSettings::CyodSettings': typeof AccountSettingsCyodSettingsComponent;
+    'account-settings/cyod-settings': typeof AccountSettingsCyodSettingsComponent;
+  }
+}

--- a/app/components/account-settings/index.ts
+++ b/app/components/account-settings/index.ts
@@ -2,10 +2,49 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import type IntlService from 'ember-intl/services/intl';
 
+import type OrganizationService from 'irene/services/organization';
+
 export default class AccountSettingsComponent extends Component {
   @service declare intl: IntlService;
+  @service declare organization: OrganizationService;
 
+  // CYOD Settings sits between Developer Settings and Notification Preferences,
+  // per the reviewed design — the Mercer setup steps send the user to Developer
+  // Settings for a Personal Token, so the two belong next to each other.
   get tabs() {
+    const notificationsIndex = this.baseTabs.findIndex((tab) =>
+      tab.route.endsWith('.notification-settings')
+    );
+
+    if (notificationsIndex === -1) {
+      return [...this.baseTabs, ...this.cyodTabs];
+    }
+
+    return [
+      ...this.baseTabs.slice(0, notificationsIndex),
+      ...this.cyodTabs,
+      ...this.baseTabs.slice(notificationsIndex),
+    ];
+  }
+
+  // Every user role registers their own CYOD device here, so the tab is gated on
+  // the org's `cyod` entitlement only — not on the owner's registration switch,
+  // which merely blocks new enrolments while the device list stays useful.
+  get cyodTabs() {
+    if (!this.organization.isCyodEnabled) {
+      return [];
+    }
+
+    return [
+      {
+        label: this.intl.t('cyod.settings.tabLabel'),
+        route: 'authenticated.dashboard.account-settings.cyod-settings',
+        activeRoutes: 'authenticated.dashboard.account-settings.cyod-settings',
+      },
+    ];
+  }
+
+  get baseTabs() {
     return [
       {
         label: this.intl.t('general'),

--- a/app/components/ak-svg/toggle-automated-dast.hbs
+++ b/app/components/ak-svg/toggle-automated-dast.hbs
@@ -3,6 +3,7 @@
   height='109'
   viewBox='0 0 177 109'
   fill='none'
+  ...attributes
   xmlns='http://www.w3.org/2000/svg'
 >
   <g clip-path='url(#clip0_23993_82972)'>

--- a/app/components/appknox-wrapper/index.ts
+++ b/app/components/appknox-wrapper/index.ts
@@ -167,7 +167,7 @@ export default class AppknoxWrapperComponent extends Component<AppknoxWrapperSig
         icon: 'account-box',
         route: 'authenticated.dashboard.account-settings.general',
         currentWhen:
-          'authenticated.dashboard.account-settings.general authenticated.dashboard.account-settings.security authenticated.dashboard.account-settings.developersettings authenticated.dashboard.account-settings.notification-settings',
+          'authenticated.dashboard.account-settings.general authenticated.dashboard.account-settings.security authenticated.dashboard.account-settings.developersettings authenticated.dashboard.account-settings.notification-settings authenticated.dashboard.account-settings.cyod-settings',
       },
       this.showMarketplace && {
         label: this.intl.t('marketplace'),

--- a/app/components/cyod-device-registration/index.hbs
+++ b/app/components/cyod-device-registration/index.hbs
@@ -1,0 +1,81 @@
+<AkStack data-test-cyodRegistration @direction='column' @spacing='2'>
+  {{#if this.isCyodEnabled}}
+    {{#if this.isAndroid}}
+      {{#if this.isWebUsbSupported}}
+        {{#if this.isDeviceDetected}}
+          <AkStack @spacing='1' @alignItems='center'>
+            <AkIcon @iconName='check-circle' @color='success' />
+
+            <AkTypography @variant='subtitle2'>
+              {{t 'cyod.deviceDetected'}}
+              <strong>{{this.detectedModel}}</strong>
+              {{t 'cyod.deviceDetectedOs'}}:
+              {{this.platformLabel}}
+              {{this.detectedOsVersion}}
+            </AkTypography>
+          </AkStack>
+        {{else}}
+          <AkTypography @color='textSecondary'>
+            {{t 'cyod.connectUsb'}}
+          </AkTypography>
+
+          <AkButton
+            data-test-cyodRegistration-registerAndroidBtn
+            @variant='outlined'
+            @loading={{this.registerAndroidDevice.isRunning}}
+            {{on 'click' this.handleRegisterClick}}
+          >
+            {{t 'cyod.registerAndroid'}}
+          </AkButton>
+        {{/if}}
+      {{else}}
+        <AkStack @spacing='1' @alignItems='center'>
+          <AkIcon @iconName='warning' @color='warn' />
+
+          <AkTypography @color='textSecondary'>
+            {{t 'cyod.usbNotSupported'}}
+          </AkTypography>
+        </AkStack>
+      {{/if}}
+    {{else if this.isIos}}
+      {{#if this.isDeviceDetected}}
+        <AkStack @spacing='1' @alignItems='center'>
+          <AkIcon @iconName='check-circle' @color='success' />
+
+          <AkTypography @variant='subtitle2'>
+            {{t 'cyod.deviceDetected'}}
+            <strong>{{this.detectedModel}}</strong>
+            {{t 'cyod.deviceDetectedOs'}}:
+            {{this.platformLabel}}
+            {{this.detectedOsVersion}}
+          </AkTypography>
+        </AkStack>
+      {{else}}
+        <AkTypography @color='textSecondary'>
+          {{t 'cyod.connectUsb'}}
+        </AkTypography>
+
+        <AkButton
+          data-test-cyodRegistration-registerIosBtn
+          @variant='outlined'
+          @loading={{this.registerIosDevice.isRunning}}
+          {{on 'click' this.handleRegisterClick}}
+        >
+          {{t 'cyod.registerIos'}}
+        </AkButton>
+      {{/if}}
+    {{/if}}
+  {{else}}
+    <AkStack
+      data-test-cyodRegistration-notEnabled
+      @spacing='1'
+      @alignItems='center'
+    >
+      <AkIcon @iconName='info' @color='textSecondary' />
+
+      <AkTypography @color='textSecondary'>
+        {{t 'cyod.notEnabled'}}
+      </AkTypography>
+    </AkStack>
+  {{/if}}
+</AkStack>

--- a/app/components/cyod-device-registration/index.ts
+++ b/app/components/cyod-device-registration/index.ts
@@ -1,0 +1,250 @@
+/**
+ * CYOD Device Registration Wizard
+ *
+ * Handles two registration paths:
+ *   Android — WebUSB via @yume-chan/adb (Chrome/Edge only)
+ *   iOS     — KnoxOps localhost agent on port 17392
+ *
+ * On success, calls @onDeviceRegistered with the device_identifier
+ * returned by moriarty's POST /devicefarm/v2/devices/webusb-register/.
+ */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import type IntlService from 'ember-intl/services/intl';
+
+import ENUMS from 'irene/enums';
+import type DevicefarmService from 'irene/services/devicefarm';
+import type IreneAjaxService from 'irene/services/ajax';
+import type CyodAdbSessionService from 'irene/services/cyod-adb-session';
+import type OrganizationService from 'irene/services/organization';
+import type LoggerService from 'irene/services/logger';
+
+const KNOXOPS_AGENT_PORT = 17392;
+const WEBUSB_REGISTER_PATH = '/devicefarm/v2/devices/webusb-register/';
+
+type WebUSBRegisteredDevice = {
+  device_identifier: string;
+  model: string;
+  platform_version: string;
+  serial_number: string;
+};
+
+export interface CyodDeviceRegistrationSignature {
+  Args: {
+    platform: number;
+    onDeviceRegistered: (device: WebUSBRegisteredDevice) => void;
+  };
+}
+
+export default class CyodDeviceRegistrationComponent extends Component<CyodDeviceRegistrationSignature> {
+  @service declare intl: IntlService;
+  @service declare devicefarm: DevicefarmService;
+  @service declare ajax: IreneAjaxService;
+  @service('notifications') declare notify: NotificationService;
+  @service('cyod-adb-session') declare cyodAdbSession: CyodAdbSessionService;
+  @service declare organization: OrganizationService;
+  @service declare logger: LoggerService;
+
+  @tracked detectedSerial: string | null = null;
+  @tracked detectedModel: string | null = null;
+  @tracked detectedOsVersion: string | null = null;
+  @tracked detectedArch: string | null = null;
+
+  get isCyodEnabled() {
+    return this.organization.isCyodEnabled;
+  }
+
+  get isAndroid() {
+    return this.args.platform === ENUMS.PLATFORM.ANDROID;
+  }
+
+  get isIos() {
+    return this.args.platform === ENUMS.PLATFORM.IOS;
+  }
+
+  get platformLabel() {
+    return this.isAndroid ? this.intl.t('android') : this.intl.t('ios');
+  }
+
+  get isWebUsbSupported() {
+    return typeof navigator !== 'undefined' && 'usb' in navigator;
+  }
+
+  get isDeviceDetected() {
+    return !!this.detectedSerial;
+  }
+
+  @action
+  handleRegisterClick() {
+    if (this.isAndroid) {
+      this.registerAndroidDevice.perform();
+    } else {
+      this.registerIosDevice.perform();
+    }
+  }
+
+  registerAndroidDevice = task(async () => {
+    if (!this.isWebUsbSupported) {
+      this.notify.error(this.intl.t('cyod.usbNotSupported'));
+
+      return;
+    }
+
+    try {
+      // Dynamically import to avoid SSR/test issues
+      const { AdbWebUsbBackendManager } = await import(
+        '@yume-chan/adb-backend-webusb'
+      );
+      const { Adb, AdbDaemonTransport } = await import('@yume-chan/adb');
+
+      const usbDevice = await AdbWebUsbBackendManager.BROWSER?.requestDevice();
+
+      if (!usbDevice) {
+        return;
+      }
+
+      const transport = await AdbDaemonTransport.authenticate({
+        serial: usbDevice.serial,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        connection: (await usbDevice.connect()) as any,
+        credentialStore: {
+          // Generate a throwaway RSA key (POC — production should persist this)
+          generateKey: async () => {
+            const keyPair = await crypto.subtle.generateKey(
+              {
+                name: 'RSASSA-PKCS1-v1_5',
+                modulusLength: 2048,
+                publicExponent: new Uint8Array([1, 0, 1]),
+                hash: 'SHA-1',
+              },
+              true,
+              ['sign', 'verify']
+            );
+            const pkcs8 = await crypto.subtle.exportKey(
+              'pkcs8',
+              keyPair.privateKey
+            );
+
+            return { buffer: new Uint8Array(pkcs8) };
+          },
+          iterateKeys: async function* () {
+            /* no stored keys */
+          },
+        },
+      });
+
+      const adb = new Adb(transport);
+
+      const serial = usbDevice.serial;
+      const model = (
+        await adb.subprocess.noneProtocol.spawnWaitText([
+          'getprop',
+          'ro.product.model',
+        ])
+      ).trim();
+      const osVersion = (
+        await adb.subprocess.noneProtocol.spawnWaitText([
+          'getprop',
+          'ro.build.version.release',
+        ])
+      ).trim();
+      const arch = (
+        await adb.subprocess.noneProtocol.spawnWaitText([
+          'getprop',
+          'ro.product.cpu.abi',
+        ])
+      ).trim();
+
+      this.detectedSerial = serial;
+      this.detectedModel = model;
+      this.detectedOsVersion = osVersion;
+      this.detectedArch = arch;
+
+      // Keep the ADB connection alive for auto-install once the scan starts.
+      // CyodAdbSessionService will dispose it after 10 min or on scan stop.
+      this.cyodAdbSession.store(serial, adb);
+
+      await this._postRegistration(
+        serial,
+        ENUMS.PLATFORM.ANDROID,
+        model,
+        osVersion,
+        arch
+      );
+    } catch (err) {
+      this.notify.error(this.intl.t('cyod.registrationFailed'));
+      this.logger.error('[CYOD] Android registration error:', err);
+    }
+  });
+
+  registerIosDevice = task(async () => {
+    try {
+      // KnoxOps agent: GET http://localhost:17392/device-info
+      const agentUrl = `http://localhost:${KNOXOPS_AGENT_PORT}/device-info`;
+      const response = await fetch(agentUrl);
+
+      if (!response.ok) {
+        this.notify.error(this.intl.t('cyod.iosAgentNotFound'));
+
+        return;
+      }
+
+      const info = (await response.json()) as {
+        udid: string;
+        model: string;
+        product_version: string;
+        cpu_architecture: string;
+      };
+
+      this.detectedSerial = info.udid;
+      this.detectedModel = info.model;
+      this.detectedOsVersion = info.product_version;
+      this.detectedArch = info.cpu_architecture ?? 'arm64e';
+
+      await this._postRegistration(
+        info.udid,
+        ENUMS.PLATFORM.IOS,
+        info.model,
+        info.product_version,
+        this.detectedArch
+      );
+    } catch {
+      this.notify.error(this.intl.t('cyod.iosAgentNotFound'));
+    }
+  });
+
+  async _postRegistration(
+    serialNumber: string,
+    platform: number,
+    model: string,
+    platformVersion: string,
+    cpuArchitecture: string
+  ) {
+    const url = new URL(WEBUSB_REGISTER_PATH, this.devicefarm.urlbase).href;
+
+    const device = await this.ajax.post<WebUSBRegisteredDevice>(url, {
+      data: JSON.stringify({
+        serial_number: serialNumber,
+        platform,
+        model,
+        platform_version: platformVersion,
+        cpu_architecture: cpuArchitecture,
+        name: model,
+      }),
+      contentType: 'application/json',
+    });
+
+    this.notify.success(this.intl.t('cyod.deviceRegistered'));
+    this.args.onDeviceRegistered(device);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    CyodDeviceRegistration: typeof CyodDeviceRegistrationComponent;
+    'cyod-device-registration': typeof CyodDeviceRegistrationComponent;
+  }
+}

--- a/app/components/cyod/device-table/index.hbs
+++ b/app/components/cyod/device-table/index.hbs
@@ -1,0 +1,128 @@
+<div
+  local-class='device-table-container'
+  data-test-cyodDeviceTable
+  ...attributes
+>
+  {{#if @heading}}
+    <AkStack
+      class='mb-2'
+      @alignItems='flex-start'
+      @justifyContent='space-between'
+      @spacing='2'
+    >
+      <AkStack @direction='column' @spacing='1'>
+        <AkTypography @variant='subtitle1' data-test-cyodDeviceTable-heading>
+          {{@heading}}
+        </AkTypography>
+
+        {{#if @subheading}}
+          <AkTypography @variant='body2' @color='textSecondary'>
+            {{@subheading}}
+          </AkTypography>
+        {{/if}}
+      </AkStack>
+
+      <AkIconButton
+        data-test-cyodDeviceTable-refreshBtn
+        @size='small'
+        @variant='outlined'
+        {{on 'click' this.handleRefresh}}
+      >
+        <AkIcon @iconName='refresh' />
+      </AkIconButton>
+    </AkStack>
+  {{/if}}
+
+  {{#if this.isLoading}}
+    <AkStack
+      local-class='loading-state'
+      data-test-cyodDeviceTable-loading
+      @spacing='1'
+      @alignItems='center'
+      @justifyContent='center'
+    >
+      <AkLoader @size={{16}} />
+
+      <AkTypography @variant='body2' @color='textSecondary'>
+        {{t 'loading'}}
+      </AkTypography>
+    </AkStack>
+
+  {{else if this.notConfigured}}
+    <div local-class='empty-state' data-test-cyodDeviceTable-notConfigured>
+      <AkIcon @iconName='info' @color='textSecondary' />
+
+      <AkTypography @variant='body2' @color='textSecondary'>
+        {{t 'cyod.deviceRegistration.notConfigured'}}
+      </AkTypography>
+    </div>
+
+  {{else if this.hasDevices}}
+    <AkTable
+      @dense={{true}}
+      @variant='semi-bordered'
+      @borderColor='dark'
+      data-test-cyodDeviceTable-table
+      as |t|
+    >
+      <t.head data-test-cyodDeviceTable-thead @columns={{this.columns}} />
+
+      <t.body local-class='table-body' @rows={{this.rows}} as |b|>
+        <b.row data-test-cyodDeviceTable-row as |r|>
+          <r.cell data-test-cyodDeviceTable-cell as |value|>
+            {{#if r.columnValue.component}}
+              {{#let (component r.columnValue.component) as |Component|}}
+                <Component @device={{r.rowValue}} />
+              {{/let}}
+            {{else}}
+              <AkTypography @noWrap={{true}} title={{value}}>
+                {{value}}
+              </AkTypography>
+            {{/if}}
+          </r.cell>
+        </b.row>
+      </t.body>
+    </AkTable>
+
+  {{else}}
+    <div local-class='empty-state-block' data-test-cyodDeviceTable-empty>
+      <AkStack
+        @alignItems='center'
+        @justifyContent='center'
+        @direction='column'
+        @spacing='1'
+        class='py-7 px-4'
+      >
+        <AkSvg::ProjectListEmpty
+          width='155px'
+          height='63px'
+          data-test-cyodDeviceTable-emptySvg
+        />
+
+        <AkStack @direction='column' @alignItems='center' @spacing='0.5'>
+          <AkTypography
+            @variant='body1'
+            @tag='h5'
+            @fontWeight='medium'
+            data-test-cyodDeviceTable-emptyTitle
+          >
+            {{t 'cyod.deviceTable.emptyTitle'}}
+          </AkTypography>
+
+          {{#if @emptyHint}}
+            <AkTypography
+              local-class='empty-description'
+              @variant='body2'
+              @align='center'
+              data-test-cyodDeviceTable-emptyDescription
+            >
+              {{@emptyHint}}
+            </AkTypography>
+          {{/if}}
+        </AkStack>
+
+        {{yield to='emptyAction'}}
+      </AkStack>
+    </div>
+  {{/if}}
+</div>

--- a/app/components/cyod/device-table/index.scss
+++ b/app/components/cyod/device-table/index.scss
@@ -1,0 +1,33 @@
+.device-table-container {
+  width: 100%;
+}
+
+.table-body {
+  border: 1px solid var(--cyod-device-table-empty-state-border-color);
+  border-radius: var(--cyod-device-table-empty-state-border-radius);
+}
+
+.loading-state {
+  padding: 1.71429em;
+  border: 1px solid var(--cyod-device-table-loading-state-border-color);
+  border-radius: var(--cyod-device-table-loading-state-border-radius);
+}
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 1.14286em;
+  border: 1px solid var(--cyod-device-table-empty-state-border-color);
+  border-radius: var(--cyod-device-table-empty-state-border-radius);
+  background: var(--cyod-device-table-empty-state-background);
+}
+
+.empty-state-block {
+  border: 1px solid var(--cyod-device-table-empty-state-block-border-color);
+  border-radius: var(--cyod-device-table-empty-state-block-border-radius);
+}
+
+.empty-description {
+  max-width: 345px;
+}

--- a/app/components/cyod/device-table/index.ts
+++ b/app/components/cyod/device-table/index.ts
@@ -1,0 +1,178 @@
+/**
+ * CYOD registered-device table.
+ *
+ * Shared by the org-settings CYOD panel (all of the org's devices, owner view)
+ * and the account-settings CYOD tab (the member's own connected device). Both
+ * read the same mycroft endpoint, which proxies moriarty's device list scoped to
+ * the org's external/Mercer-registered devices — so the only difference between
+ * the two callers is the surrounding copy, not the data.
+ */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import dayjs from 'dayjs';
+import type IntlService from 'ember-intl/services/intl';
+
+import type IreneAjaxService from 'irene/services/ajax';
+import type { AjaxError } from 'irene/services/ajax';
+import type OrganizationService from 'irene/services/organization';
+
+export type RegisteredDevice = {
+  id: number;
+  name?: string;
+  serial_number: string;
+  model: string;
+  platform: number;
+  is_connected: boolean;
+  created_on?: string;
+};
+
+type RegisteredDevicesResponse = {
+  results: RegisteredDevice[];
+};
+
+export type DeviceRow = {
+  id: number;
+  deviceName: string;
+  registeredOn: string;
+  isConnected: boolean;
+};
+
+export interface CyodDeviceTableSignature {
+  Element: HTMLDivElement;
+  Args: {
+    // Rendered instead of the table when the org has no registered devices.
+    // Callers differ here: the org panel points at the account-settings tab,
+    // the account tab points at its own "Register a device" button.
+    emptyHint?: string;
+    // When set, the table renders its own header row (title, optional
+    // description, refresh button). Omit it to render the bare table.
+    heading?: string;
+    subheading?: string;
+    // Show only devices currently online. Used by the account-settings view
+    // ("Your connected device"), where an offline device is not actionable.
+    // The org view leaves this off so owners see the full inventory.
+    onlyConnected?: boolean;
+  };
+  Blocks: {
+    emptyAction?: [];
+  };
+}
+
+export default class CyodDeviceTableComponent extends Component<CyodDeviceTableSignature> {
+  @service declare intl: IntlService;
+  @service declare ajax: IreneAjaxService;
+  @service declare organization: OrganizationService;
+
+  @tracked devices: RegisteredDevice[] = [];
+
+  // The org has CYOD enabled but no devicefarm token configured (mycroft returns
+  // 400). Distinct from "configured but no devices yet" so the UI can guide the
+  // user to their admin instead of showing a dead-end empty state.
+  @tracked notConfigured = false;
+
+  constructor(owner: unknown, args: CyodDeviceTableSignature['Args']) {
+    super(owner, args);
+
+    this.reload.perform();
+  }
+
+  get devicesUrl() {
+    return `/api/organizations/${this.organization.selected?.id}/registered-devices`;
+  }
+
+  get visibleDevices() {
+    if (this.args.onlyConnected) {
+      return this.devices.filter((device) => device.is_connected);
+    }
+
+    return this.devices;
+  }
+
+  get hasDevices() {
+    return this.visibleDevices.length > 0;
+  }
+
+  get isLoading() {
+    return this.reload.isRunning;
+  }
+
+  // ember-table spreads leftover width across every column, so the name column
+  // only gets a fair share of it unless it is given a much larger base width.
+  // Weighting it this way pulls the two trailing columns left and leaves room
+  // for long device names before they truncate.
+  get columns() {
+    return [
+      {
+        name: this.intl.t('cyod.deviceTable.name'),
+        valuePath: 'deviceName',
+        width: 340,
+        minWidth: 180,
+      },
+      {
+        name: this.intl.t('cyod.deviceTable.registeredOn'),
+        valuePath: 'registeredOn',
+        textAlign: 'left',
+        width: 130,
+      },
+      {
+        // ember-table puts `ember-table__text-align-center` on the header and
+        // body cells alike, so the chip centres under its own heading.
+        name: this.intl.t('cyod.deviceTable.status'),
+        component: 'cyod/device-table/status',
+        textAlign: 'center',
+        width: 120,
+      },
+    ];
+  }
+
+  get rows(): DeviceRow[] {
+    return this.visibleDevices.map((device) => ({
+      id: device.id,
+      deviceName: device.name || device.model || device.serial_number,
+      registeredOn: device.created_on
+        ? dayjs(device.created_on).format('D MMMM YYYY')
+        : '-',
+      isConnected: device.is_connected,
+    }));
+  }
+
+  @action
+  handleRefresh() {
+    this.reload.perform();
+  }
+
+  reload = task({ drop: true }, async () => {
+    const orgId = this.organization.selected?.id;
+
+    this.notConfigured = false;
+
+    if (!orgId) {
+      this.devices = [];
+
+      return;
+    }
+
+    try {
+      const result = await this.ajax.request<RegisteredDevicesResponse>(
+        this.devicesUrl
+      );
+
+      this.devices = result.results ?? [];
+    } catch (e) {
+      // 400 = CYOD device farm not configured for this org (no devicefarm
+      // token). Surfaced distinctly instead of the generic empty state.
+      this.notConfigured = (e as AjaxError)?.status === 400;
+      this.devices = [];
+    }
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Cyod::DeviceTable': typeof CyodDeviceTableComponent;
+    'cyod/device-table': typeof CyodDeviceTableComponent;
+  }
+}

--- a/app/components/cyod/device-table/status/index.hbs
+++ b/app/components/cyod/device-table/status/index.hbs
@@ -1,0 +1,12 @@
+<AkChip
+  data-test-cyodDeviceTable-statusChip
+  @variant='semi-filled'
+  @size='small'
+  @fontWeight='medium'
+  @color={{if @device.isConnected 'success' 'secondary'}}
+  @label={{if
+    @device.isConnected
+    (t 'cyod.deviceRegistration.online')
+    (t 'cyod.deviceRegistration.offline')
+  }}
+/>

--- a/app/components/cyod/device-table/status/index.ts
+++ b/app/components/cyod/device-table/status/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Device Status cell for the CYOD device table — Online / Offline chip.
+ *
+ * Rendered through AkTable's `component` column hook, which passes the row value
+ * as `@device`.
+ */
+import Component from '@glimmer/component';
+
+import type { DeviceRow } from 'irene/components/cyod/device-table';
+
+export interface CyodDeviceTableStatusSignature {
+  Element: HTMLDivElement;
+  Args: {
+    device: DeviceRow;
+  };
+}
+
+export default class CyodDeviceTableStatusComponent extends Component<CyodDeviceTableStatusSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Cyod::DeviceTable::Status': typeof CyodDeviceTableStatusComponent;
+    'cyod/device-table/status': typeof CyodDeviceTableStatusComponent;
+  }
+}

--- a/app/routes/authenticated/dashboard/account-settings/cyod-settings.ts
+++ b/app/routes/authenticated/dashboard/account-settings/cyod-settings.ts
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { ScrollToTop } from 'irene/utils/scroll-to-top';
+import type UserModel from 'irene/models/user';
+
+export default class AuthenticatedSettingsCyodSettingsRoute extends ScrollToTop(
+  Route
+) {
+  model() {
+    return this.modelFor(
+      'authenticated.dashboard.account-settings'
+    ) as UserModel;
+  }
+}

--- a/app/styles/_component-variables.scss
+++ b/app/styles/_component-variables.scss
@@ -1685,6 +1685,45 @@ body {
     --border-color-1
   );
 
+  // variables for account-settings/cyod-settings
+  --account-settings-cyod-settings-background: var(--common-white);
+  --account-settings-cyod-settings-disabled-state-border-color: var(
+    --divider-dark
+  );
+  --account-settings-cyod-settings-disabled-state-border-radius: var(
+    --border-radius
+  );
+  --account-settings-cyod-settings-step-num-background: var(--primary-light);
+  --account-settings-cyod-settings-step-num-color: var(--primary-dark);
+  --account-settings-cyod-settings-step-num-border-radius: var(
+    --border-radius-capsule
+  );
+  --account-settings-cyod-settings-step-num-font-weight: var(
+    --font-weight-medium
+  );
+  --account-settings-cyod-settings-url-field-background: var(
+    --background-light
+  );
+  --account-settings-cyod-settings-url-field-border-color: var(--divider-dark);
+  --account-settings-cyod-settings-url-field-border-radius: var(
+    --border-radius
+  );
+  --account-settings-cyod-settings-url-value-font-family: var(
+    --font-family-mono
+  );
+
+  // variables for cyod/device-table
+  --cyod-device-table-frame-border-color: var(--divider-dark);
+  --cyod-device-table-frame-border-radius: var(--border-radius);
+  --cyod-device-table-header-font-weight: var(--font-weight-medium);
+  --cyod-device-table-empty-state-background: var(--background-light);
+  --cyod-device-table-empty-state-border-color: var(--divider-dark);
+  --cyod-device-table-empty-state-border-radius: var(--border-radius);
+  --cyod-device-table-empty-state-block-border-color: var(--divider-dark);
+  --cyod-device-table-empty-state-block-border-radius: var(--border-radius);
+  --cyod-device-table-loading-state-border-color: var(--divider-dark);
+  --cyod-device-table-loading-state-border-radius: var(--border-radius);
+
   // variables for account-settings-page-content-wrapper-border-color
   --account-settings-page-content-wrapper-border-color: var(--border-color-1);
 

--- a/app/templates/authenticated/dashboard/account-settings/cyod-settings.hbs
+++ b/app/templates/authenticated/dashboard/account-settings/cyod-settings.hbs
@@ -1,0 +1,2 @@
+{{page-title (t 'cyod.settings.tabLabel')}}
+<AccountSettings::CyodSettings />

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -97,6 +97,14 @@ function routes() {
     return schema.projects.all().models;
   });
 
+  this.get('/organizations/:id/registered-devices', (schema) => {
+    const results = schema.registeredDevices
+      .all()
+      .models.map((d) => d.toJSON());
+
+    return { count: results.length, next: null, previous: null, results };
+  });
+
   this.put('/organizations/:id', () => {
     return {};
   });

--- a/mirage/factories/organization-me.ts
+++ b/mirage/factories/organization-me.ts
@@ -1,4 +1,6 @@
-import { Factory } from 'miragejs';
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error "trait" prop missing from miragejs
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   is_admin: true,
@@ -6,4 +8,24 @@ export default Factory.extend({
   is_member: false,
   can_access_partner_dashboard: false,
   has_security_permission: false,
+
+  // `is_admin` and `is_owner` are independent on the API, so the roles are
+  // separate traits rather than one enum.
+  admin: trait({
+    is_admin: true,
+    is_owner: false,
+    is_member: false,
+  }),
+
+  owner: trait({
+    is_admin: false,
+    is_owner: true,
+    is_member: false,
+  }),
+
+  member: trait({
+    is_admin: false,
+    is_owner: false,
+    is_member: true,
+  }),
 });

--- a/mirage/factories/organization.ts
+++ b/mirage/factories/organization.ts
@@ -1,4 +1,7 @@
 import { faker } from '@faker-js/faker';
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error "trait" prop missing from miragejs
+import { trait } from 'miragejs';
 import Base from './base';
 
 export default Base.extend({
@@ -7,4 +10,17 @@ export default Base.extend({
   teamCount: faker.number.int(),
   invitationCount: faker.number.int(),
   projects_count: faker.number.int(),
+  cyod_registration_enabled: false,
+
+  // The paid CYOD entitlement, with member self-registration switched on.
+  cyodEnabled: trait({
+    features: () => ({ cyod: true }),
+    cyod_registration_enabled: true,
+  }),
+
+  // Entitled, but the owner has switched member registration off.
+  cyodRegistrationDisabled: trait({
+    features: () => ({ cyod: true }),
+    cyod_registration_enabled: false,
+  }),
 });

--- a/mirage/factories/registered-device.ts
+++ b/mirage/factories/registered-device.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error "trait" prop missing from miragejs
+import { Factory, trait } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+import ENUMS from 'irene/enums';
+
+export default Factory.extend({
+  name: () =>
+    faker.helpers.arrayElement(['Pixel 7', 'iPhone 14', 'Galaxy S23']),
+  serial_number: () =>
+    faker.string.alphanumeric({ length: 8, casing: 'upper' }),
+  model: () => faker.helpers.arrayElement(['Pixel', 'iPhone', 'Galaxy']),
+  platform: ENUMS.PLATFORM.ANDROID,
+  is_connected: true,
+  created_on: () => faker.date.recent().toISOString(),
+
+  offline: trait({
+    is_connected: false,
+  }),
+
+  ios: trait({
+    platform: ENUMS.PLATFORM.IOS,
+  }),
+
+  unnamed: trait({
+    name: null,
+  }),
+});

--- a/mirage/models/registered-device.ts
+++ b/mirage/models/registered-device.ts
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/tests/integration/components/account-settings/cyod-settings-test.js
+++ b/tests/integration/components/account-settings/cyod-settings-test.js
@@ -1,0 +1,196 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+
+class NotificationsStub extends Service {
+  success() {}
+  error() {}
+}
+
+/**
+ * Registers an organization service whose `selected` is a mirage-created
+ * organization, so the device-table URLs it drives point at a real record.
+ */
+function setupOrganization(
+  context,
+  { registrationEnabled = true, cyodEnabled = true } = {}
+) {
+  const organization = context.server.create('organization');
+
+  class OrganizationStub extends Service {
+    selected = organization;
+    isCyodEnabled = cyodEnabled;
+    isCyodRegistrationEnabled = registrationEnabled;
+  }
+
+  context.owner.register('service:organization', OrganizationStub);
+  context.organization = organization;
+
+  return organization;
+}
+
+/**
+ * Registers a `me` whose org membership carries the given role trait. Only the
+ * owner can flip the CYOD switch, so the role decides which notice they get.
+ */
+function setupMe(context, ...traits) {
+  const orgMe = context.server.create('organization-me', ...traits);
+
+  class MeStub extends Service {
+    org = orgMe;
+  }
+
+  context.owner.unregister('service:me');
+  context.owner.register('service:me', MeStub);
+
+  return orgMe;
+}
+
+module(
+  'Integration | Component | account-settings/cyod-settings',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks, 'en');
+    setupMirage(hooks);
+
+    hooks.beforeEach(function () {
+      this.owner.register('service:notifications', NotificationsStub);
+
+      setupMe(this, 'member');
+    });
+
+    test('it renders the registration section and the connected-device table', async function (assert) {
+      setupOrganization(this);
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert
+        .dom('[data-test-cyodSettings-registerTitle]')
+        .hasText(t('cyod.settings.deviceRegistration'));
+
+      assert.dom('[data-test-cyodSettings-registerBtn]').isNotDisabled();
+
+      assert
+        .dom('[data-test-cyodDeviceTable-heading]')
+        .hasText(t('cyod.settings.connectedDevice'));
+    });
+
+    test('the switch being off replaces the whole surface with a notice', async function (assert) {
+      setupOrganization(this, { registrationEnabled: false });
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert.dom('[data-test-cyodSettings-disabled]').exists();
+      assert.dom('[data-test-cyodSettings-disabledSvg]').exists();
+
+      assert
+        .dom('[data-test-cyodSettings-disabledTitle]')
+        .hasText(t('cyod.settings.turnOnTitle'));
+
+      assert
+        .dom('[data-test-cyodSettings-disabledDesc]')
+        .hasText(
+          t('cyod.settings.turnOnDesc'),
+          'a member is told to ask the owner — they cannot flip the switch'
+        );
+
+      // Nothing actionable is left on the page — a disabled button over an
+      // empty table would just be dead weight.
+      assert.dom('[data-test-cyodSettings-registerBtn]').doesNotExist();
+      assert.dom('[data-test-cyodDeviceTable]').doesNotExist();
+
+      // The heading stays so the tab still identifies itself.
+      assert
+        .dom('[data-test-cyodSettings-title]')
+        .hasText(t('cyod.registration.title'));
+    });
+
+    test('the owner is pointed at organization settings instead', async function (assert) {
+      setupOrganization(this, { registrationEnabled: false });
+      setupMe(this, 'owner');
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert
+        .dom('[data-test-cyodSettings-disabledDesc]')
+        .hasText(
+          t('cyod.settings.turnOnDescOwner'),
+          'the owner owns the switch, so telling them to contact an owner is useless'
+        );
+    });
+
+    test('an admin is told to ask the owner', async function (assert) {
+      // is_admin and is_owner are independent flags — an admin cannot flip the
+      // switch, so they get the same notice as a member.
+      setupOrganization(this, { registrationEnabled: false });
+      setupMe(this, 'admin');
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert
+        .dom('[data-test-cyodSettings-disabledDesc]')
+        .hasText(t('cyod.settings.turnOnDesc'));
+    });
+
+    test('the empty hint emphasises the register action as markup', async function (assert) {
+      setupOrganization(this);
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert
+        .dom('[data-test-cyodDeviceTable-emptyDescription] strong')
+        .hasText('Register a device', 'renders as markup, not literal tags');
+    });
+
+    test('it renders nothing without the CYOD entitlement', async function (assert) {
+      setupOrganization(this, { cyodEnabled: false });
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert
+        .dom('[data-test-cyodSettings]')
+        .doesNotExist('direct URL access must not surface CYOD UI');
+    });
+
+    test('it opens the five-step Mercer setup drawer', async function (assert) {
+      setupOrganization(this);
+
+      await render(hbs`<AccountSettings::CyodSettings />`);
+
+      assert.dom('[data-test-cyodSettings-drawer]').doesNotExist();
+
+      await click('[data-test-cyodSettings-registerBtn]');
+
+      assert.dom('[data-test-cyodSettings-drawer]').exists();
+      assert.dom('[data-test-cyodSettings-downloadBtn]').exists();
+      assert.dom('[data-test-cyodSettings-serverUrl]').exists();
+      assert.dom('[data-test-cyodSettings-copyBtn]').exists();
+
+      assert
+        .dom('[data-test-cyodSettings-drawer]')
+        .containsText(t('cyod.settings.stepRun'), 'renders the final step');
+
+      // The "Note -" label is a separate bold run, so the two notes carry it
+      // as markup rather than baked into the translated sentence.
+      const noteLabels = this.element.querySelectorAll(
+        '[data-test-cyodSettings-noteLabel]'
+      );
+
+      assert.strictEqual(noteLabels.length, 2, 'both steps carry a note label');
+
+      assert.dom(noteLabels[0]).hasText(t('cyod.settings.noteLabel'));
+
+      assert
+        .dom('[data-test-cyodSettings-drawer]')
+        .containsText(t('cyod.settings.stepCertificateNote'));
+
+      await click('[data-test-cyodSettings-drawerCloseBtn]');
+
+      assert.dom('[data-test-cyodSettings-drawer]').doesNotExist();
+    });
+  }
+);

--- a/tests/integration/components/account-settings/index-test.js
+++ b/tests/integration/components/account-settings/index-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+
+function organizationStub({ cyodEnabled = true } = {}) {
+  return class OrganizationStub extends Service {
+    selected = { id: 42 };
+    isCyodEnabled = cyodEnabled;
+  };
+}
+
+function tabLabels(element) {
+  return [...element.querySelectorAll('[data-test-ak-tab-item]')].map((el) =>
+    el.textContent.trim()
+  );
+}
+
+module('Integration | Component | account-settings', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+
+  test('the CYOD tab sits between developer settings and notifications', async function (assert) {
+    this.owner.register('service:organization', organizationStub());
+
+    await render(hbs`<AccountSettings />`);
+
+    const labels = tabLabels(this.element);
+    const cyodIndex = labels.indexOf(t('cyod.settings.tabLabel'));
+
+    assert.strictEqual(
+      cyodIndex,
+      labels.indexOf(t('developerSettings')) + 1,
+      'comes straight after developer settings'
+    );
+
+    assert.strictEqual(
+      cyodIndex + 1,
+      labels.indexOf(t('notificationPreferences')),
+      'and sits before notification preferences'
+    );
+  });
+
+  test('the CYOD tab is absent without the entitlement', async function (assert) {
+    this.owner.register(
+      'service:organization',
+      organizationStub({ cyodEnabled: false })
+    );
+
+    await render(hbs`<AccountSettings />`);
+
+    assert.notOk(
+      tabLabels(this.element).includes(t('cyod.settings.tabLabel')),
+      'no CYOD tab'
+    );
+  });
+});

--- a/tests/integration/components/cyod-device-registration-test.js
+++ b/tests/integration/components/cyod-device-registration-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
+import Service from '@ember/service';
+
+import ENUMS from 'irene/enums';
+
+class OrganizationStub extends Service {
+  cyodEnabled = false;
+
+  get isCyodEnabled() {
+    return this.cyodEnabled;
+  }
+}
+
+module('Integration | Component | cyod-device-registration', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:organization', OrganizationStub);
+    this.orgStub = this.owner.lookup('service:organization');
+    this.set('platform', ENUMS.PLATFORM.ANDROID);
+    this.set('onDeviceRegistered', () => {});
+  });
+
+  test('it gates the wizard behind the cyod feature flag', async function (assert) {
+    this.orgStub.cyodEnabled = false;
+
+    await render(hbs`
+        <CyodDeviceRegistration
+          @platform={{this.platform}}
+          @onDeviceRegistered={{this.onDeviceRegistered}}
+        />
+      `);
+
+    assert
+      .dom('[data-test-cyodRegistration-notEnabled]')
+      .exists('shows the not-enabled notice when cyod is disabled');
+    assert
+      .dom('[data-test-cyodRegistration-registerAndroidBtn]')
+      .doesNotExist('hides the register wizard when cyod is disabled');
+  });
+
+  test('it shows the wizard when the cyod feature is enabled', async function (assert) {
+    this.orgStub.cyodEnabled = true;
+
+    await render(hbs`
+        <CyodDeviceRegistration
+          @platform={{this.platform}}
+          @onDeviceRegistered={{this.onDeviceRegistered}}
+        />
+      `);
+
+    assert
+      .dom('[data-test-cyodRegistration-notEnabled]')
+      .doesNotExist('the not-enabled notice is gone when cyod is enabled');
+  });
+});

--- a/tests/integration/components/cyod/device-table-test.js
+++ b/tests/integration/components/cyod/device-table-test.js
@@ -1,0 +1,155 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+import dayjs from 'dayjs';
+
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+const selectors = {
+  table: '[data-test-cyodDeviceTable-table]',
+  row: '[data-test-cyodDeviceTable-row]',
+  statusChip: '[data-test-cyodDeviceTable-statusChip]',
+  heading: '[data-test-cyodDeviceTable-heading]',
+  refreshBtn: '[data-test-cyodDeviceTable-refreshBtn]',
+  empty: '[data-test-cyodDeviceTable-empty]',
+  emptyTitle: '[data-test-cyodDeviceTable-emptyTitle]',
+  emptyDescription: '[data-test-cyodDeviceTable-emptyDescription]',
+  notConfigured: '[data-test-cyodDeviceTable-notConfigured]',
+};
+
+// ─── Templates ─────────────────────────────────────────────────────────────────
+const BARE = hbs`<Cyod::DeviceTable />`;
+const ONLY_CONNECTED = hbs`<Cyod::DeviceTable @onlyConnected={{true}} />`;
+
+module('Integration | Component | cyod/device-table', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    const organization = this.server.create('organization');
+
+    class OrganizationStub extends Service {
+      selected = organization;
+    }
+
+    this.owner.register('service:organization', OrganizationStub);
+    this.organization = organization;
+  });
+
+  test('it renders the registered devices with name, date and status', async function (assert) {
+    const device = this.server.create('registered-device');
+
+    await render(BARE);
+
+    assert.dom(selectors.table).exists();
+    assert.dom(selectors.row).exists({ count: 1 });
+    assert.dom(selectors.table).containsText(device.name);
+
+    assert
+      .dom(selectors.table)
+      .containsText(dayjs(device.created_on).format('D MMMM YYYY'));
+
+    const chip = this.element.querySelector(selectors.statusChip);
+
+    assert.dom(chip).hasText(t('cyod.deviceRegistration.online'));
+
+    // The chip centres via the column's textAlign, which ember-table turns
+    // into a class on the cell — the chip itself is inline-flex.
+    assert
+      .dom(chip.closest('td'))
+      .hasClass(
+        'ember-table__text-align-center',
+        'status column is centre-aligned'
+      );
+  });
+
+  test('it falls back to the serial number and a dash when name and date are absent', async function (assert) {
+    const device = this.server.create(
+      'registered-device',
+      'unnamed',
+      'offline',
+      {
+        model: '',
+        created_on: null,
+      }
+    );
+
+    await render(BARE);
+
+    assert
+      .dom(selectors.table)
+      .containsText(device.serial_number, 'falls back to the serial number');
+
+    assert.dom(selectors.table).containsText('-', 'no date renders as a dash');
+
+    assert
+      .dom(selectors.statusChip)
+      .hasText(t('cyod.deviceRegistration.offline'));
+  });
+
+  test('@onlyConnected keeps just the online devices', async function (assert) {
+    const online = this.server.create('registered-device');
+    const offline = this.server.create('registered-device', 'offline', 'ios');
+
+    // The org view shows the full inventory, online and offline alike.
+    await render(BARE);
+
+    assert.dom(selectors.row).exists({ count: 2 });
+
+    // "Your connected device" only lists what is actually reachable.
+    await render(ONLY_CONNECTED);
+
+    assert.dom(selectors.row).exists({ count: 1 });
+    assert.dom(selectors.table).containsText(online.name);
+    assert.dom(selectors.table).doesNotContainText(offline.serial_number);
+  });
+
+  test('@onlyConnected falls back to the empty state when every device is offline', async function (assert) {
+    this.server.create('registered-device', 'offline');
+
+    await render(ONLY_CONNECTED);
+
+    assert.dom(selectors.empty).exists();
+    assert.dom(selectors.table).doesNotExist();
+  });
+
+  test('it shows the empty state when the org has no devices', async function (assert) {
+    await render(hbs`<Cyod::DeviceTable @emptyHint='Register one first' />`);
+
+    assert.dom(selectors.empty).exists();
+    assert.dom(selectors.empty).containsText(t('cyod.deviceTable.emptyTitle'));
+    assert.dom(selectors.empty).containsText('Register one first');
+    assert.dom(selectors.table).doesNotExist();
+    assert.dom(selectors.emptyTitle).hasText(t('cyod.deviceTable.emptyTitle'));
+  });
+
+  test('it distinguishes an unconfigured device farm (400) from an empty list', async function (assert) {
+    this.server.get(
+      '/organizations/:id/registered-devices',
+      () => ({
+        errors: [{ status: 400 }],
+      }),
+      400
+    );
+
+    await render(BARE);
+
+    assert.dom(selectors.notConfigured).exists();
+    assert.dom(selectors.empty).doesNotExist();
+  });
+
+  test('it renders a header with a refresh button only when a heading is given', async function (assert) {
+    await render(BARE);
+
+    assert.dom(selectors.refreshBtn).doesNotExist();
+
+    await render(hbs`<Cyod::DeviceTable @heading='Your connected device' />`);
+
+    assert.dom(selectors.heading).hasText('Your connected device');
+    assert.dom(selectors.refreshBtn).exists();
+  });
+});


### PR DESCRIPTION
2/7 in the CYOD stack. Bases on #1712 (cyod-01-foundation). Merge in order 01→07.

The Account Settings → CYOD Settings tab: the register-a-device drawer with its Mercer setup steps, the device table, and the two empty states (no devices registered / CYOD turned off).

Design review applied: 500px drawer, DM Mono server URL at 12px with an 11px token hint, 14px/600 empty-state headers over 13px subtext capped at 345px, and the tray illustration from the Figma frame.

cc @Yibaebi