### PR TITLE
feat(cyod): owner switch for organization device registration

### DIFF
--- a/app/components/cyod-device-registration/index.hbs
+++ b/app/components/cyod-device-registration/index.hbs
@@ -31,7 +31,6 @@
       {{else}}
         <AkStack @spacing='1' @alignItems='center'>
           <AkIcon @iconName='warning' @color='warn' />
-
           <AkTypography @color='textSecondary'>
             {{t 'cyod.usbNotSupported'}}
           </AkTypography>
@@ -72,7 +71,6 @@
       @alignItems='center'
     >
       <AkIcon @iconName='info' @color='textSecondary' />
-
       <AkTypography @color='textSecondary'>
         {{t 'cyod.notEnabled'}}
       </AkTypography>

--- a/app/components/cyod-device-registration/index.hbs
+++ b/app/components/cyod-device-registration/index.hbs
@@ -31,6 +31,7 @@
       {{else}}
         <AkStack @spacing='1' @alignItems='center'>
           <AkIcon @iconName='warning' @color='warn' />
+
           <AkTypography @color='textSecondary'>
             {{t 'cyod.usbNotSupported'}}
           </AkTypography>
@@ -71,6 +72,7 @@
       @alignItems='center'
     >
       <AkIcon @iconName='info' @color='textSecondary' />
+
       <AkTypography @color='textSecondary'>
         {{t 'cyod.notEnabled'}}
       </AkTypography>

--- a/app/components/organization/device-registration/index.hbs
+++ b/app/components/organization/device-registration/index.hbs
@@ -1,0 +1,57 @@
+<div class='w-full' data-test-orgDeviceRegistration ...attributes>
+  <AkStack @direction='column' @spacing='0.5'>
+    <AkStack
+      @width='full'
+      @alignItems='center'
+      @justifyContent='space-between'
+      @spacing='2'
+    >
+      <AkTypography @variant='h5' data-test-orgDeviceRegistration-title>
+        {{t 'cyod.registration.title'}}
+      </AkTypography>
+
+      <AkToggle
+        data-test-orgDeviceRegistration-toggle
+        @id='cyod-registration'
+        @checked={{this.isRegistrationEnabled}}
+        @disabled={{this.isSaving}}
+        @size='small'
+        @onChange={{perform this.setRegistrationEnabled}}
+      />
+    </AkStack>
+
+    <AkTypography
+      @variant='body2'
+      @color='textSecondary'
+      {{style maxWidth='500px'}}
+      data-test-orgDeviceRegistration-description
+    >
+      {{t 'cyod.registration.description'}}
+    </AkTypography>
+  </AkStack>
+
+  {{#if this.isRegistrationEnabled}}
+    <div class='mt-2'>
+      <Cyod::DeviceTable @emptyHint={{t 'cyod.registration.emptyHint'}}>
+        <:emptyAction>
+          <AkLink
+            data-test-orgDeviceRegistration-goToCyodSettings
+            @route='authenticated.dashboard.account-settings.cyod-settings'
+            @color='primary'
+            @underline='always'
+            @typographyVariant='body2'
+            @fontWeight='medium'
+          >
+            <:default>
+              {{t 'cyod.registration.goToCyodSettings'}}
+            </:default>
+
+            <:rightIcon>
+              <AkIcon @iconName='open-in-new' @size='small' @color='primary' />
+            </:rightIcon>
+          </AkLink>
+        </:emptyAction>
+      </Cyod::DeviceTable>
+    </div>
+  {{/if}}
+</div>

--- a/app/components/organization/device-registration/index.ts
+++ b/app/components/organization/device-registration/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Organization CYOD Registration panel (owners).
+ *
+ * An add-on section in Organization Settings: an owner switch for CYOD device
+ * self-registration, plus a read-only table of the org's registered devices.
+ *
+ * Registration itself does NOT happen here — a member enrols their own device
+ * from Account Settings → CYOD Settings using the Mercer app. This panel is the
+ * org-wide view and kill-switch.
+ *
+ * The switch (`cyodRegistrationEnabled`) is layered under the paid `cyod`
+ * entitlement, which stays tech-admin controlled. Flipping it off blocks new
+ * enrolments server-side; devices already registered keep serving scans.
+ */
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import type IntlService from 'ember-intl/services/intl';
+
+import type OrganizationService from 'irene/services/organization';
+import parseError from 'irene/utils/parse-error';
+
+export interface OrganizationDeviceRegistrationSignature {
+  Element: HTMLDivElement;
+}
+
+export default class OrganizationDeviceRegistrationComponent extends Component<OrganizationDeviceRegistrationSignature> {
+  @service declare intl: IntlService;
+  @service declare organization: OrganizationService;
+  @service('notifications') declare notify: NotificationService;
+
+  @tracked isSaving = false;
+
+  // AkToggle's inner <Input @checked> is a two-way binding, so this needs a
+  // setter as well as a getter. `pendingState` holds the optimistic value while
+  // the save is in flight; until then the persisted org value is the source of
+  // truth (the org loads asynchronously).
+  @tracked pendingState: boolean | null = null;
+
+  get isRegistrationEnabled() {
+    if (this.pendingState !== null) {
+      return this.pendingState;
+    }
+
+    return !!this.organization.selected?.cyodRegistrationEnabled;
+  }
+
+  set isRegistrationEnabled(checked: boolean) {
+    this.pendingState = checked;
+  }
+
+  setRegistrationEnabled = task(async (_evt: Event, checked: boolean) => {
+    const org = this.organization.selected;
+
+    if (!org) {
+      return;
+    }
+
+    this.isSaving = true;
+    this.pendingState = checked;
+
+    try {
+      org.set('cyodRegistrationEnabled', checked);
+
+      await org.save();
+
+      this.notify.success(this.intl.t('cyod.registration.saved'));
+    } catch (err) {
+      // Roll the toggle back so it keeps reflecting the persisted state.
+      org.set('cyodRegistrationEnabled', !checked);
+      this.pendingState = !checked;
+
+      this.notify.error(parseError(err, this.intl.t('pleaseTryAgain')));
+    } finally {
+      this.isSaving = false;
+    }
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Organization::DeviceRegistration': typeof OrganizationDeviceRegistrationComponent;
+    'organization/device-registration': typeof OrganizationDeviceRegistrationComponent;
+  }
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -105,8 +105,16 @@ function routes() {
     return { count: results.length, next: null, previous: null, results };
   });
 
-  this.put('/organizations/:id', () => {
-    return {};
+  this.put('/organizations/:id', (schema, req) => {
+    const organization = schema.organizations.find(req.params.id);
+
+    if (!organization) {
+      return {};
+    }
+
+    organization.update(JSON.parse(req.requestBody));
+
+    return organization.toJSON();
   });
 
   this.get('/organizations/:id/preference', () => {

--- a/tests/integration/components/organization/device-registration-test.js
+++ b/tests/integration/components/organization/device-registration-test.js
@@ -1,0 +1,164 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+
+// ─── Stubs ─────────────────────────────────────────────────────────────────────
+class NotificationsStub extends Service {
+  successMsg = null;
+  errorMsg = null;
+  success(msg) {
+    this.successMsg = msg;
+  }
+
+  error(msg) {
+    this.errorMsg = msg;
+  }
+}
+
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+const selectors = {
+  title: '[data-test-orgDeviceRegistration-title]',
+  description: '[data-test-orgDeviceRegistration-description]',
+  toggle: '[data-test-orgDeviceRegistration-toggle]',
+  // AkToggle puts the test attribute on the wrapping <span> and renders the
+  // real checkbox inside it, so assertions and clicks target the input.
+  toggleInput: '[data-test-orgDeviceRegistration-toggle] input',
+  goToCyodSettings: '[data-test-orgDeviceRegistration-goToCyodSettings]',
+  deviceTable: '[data-test-cyodDeviceTable]',
+  deviceTableEmpty: '[data-test-cyodDeviceTable-empty]',
+};
+
+// ─── Template ──────────────────────────────────────────────────────────────────
+const TEMPLATE = hbs`<Organization::DeviceRegistration />`;
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+/**
+ * Registers an organization service backed by a real ember-data record pushed
+ * from mirage, so the component's `set` + `save` hit the PUT route rather than
+ * a hand-written stub. Returns the mirage model and the pushed record.
+ */
+function setupOrganization(context, ...traits) {
+  const store = context.owner.lookup('service:store');
+  const organization = context.server.create('organization', ...traits);
+  const record = store.push(
+    store.normalize('organization', organization.toJSON())
+  );
+
+  class OrganizationStub extends Service {
+    selected = record;
+  }
+
+  context.owner.register('service:organization', OrganizationStub);
+  context.setProperties({ store, organization, record });
+
+  return { organization, record };
+}
+
+module(
+  'Integration | Component | organization/device-registration',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks, 'en');
+    setupMirage(hooks);
+
+    hooks.beforeEach(function () {
+      this.owner.register('service:notifications', NotificationsStub);
+      this.notify = this.owner.lookup('service:notifications');
+    });
+
+    test('it renders the CYOD registration switch turned on', async function (assert) {
+      setupOrganization(this, 'cyodEnabled');
+
+      await render(TEMPLATE);
+
+      assert
+        .dom(selectors.title)
+        .hasText(t('cyod.registration.title'))
+        .hasTagName('h5', 'title sits at the 16px section size');
+
+      assert.dom(selectors.toggleInput).isChecked();
+
+      assert
+        .dom(selectors.description)
+        .hasText(t('cyod.registration.description'));
+    });
+
+    test('it hides the device table when the switch is off', async function (assert) {
+      setupOrganization(this, 'cyodRegistrationDisabled');
+
+      await render(TEMPLATE);
+
+      assert.dom(selectors.toggleInput).isNotChecked();
+      assert.dom(selectors.deviceTable).doesNotExist();
+    });
+
+    test('toggling off persists the new value on the organization', async function (assert) {
+      const { record } = setupOrganization(this, 'cyodEnabled');
+
+      await render(TEMPLATE);
+      await click(selectors.toggleInput);
+
+      const put = this.server.pretender.handledRequests.find(
+        (r) => r.method === 'PUT'
+      );
+
+      assert.ok(put, 'saves the organization');
+
+      assert.false(
+        JSON.parse(put.requestBody).cyod_registration_enabled,
+        'sends the value the switch was moved to, not its inverse'
+      );
+
+      assert.false(
+        record.cyodRegistrationEnabled,
+        'the record keeps the persisted value'
+      );
+
+      assert.strictEqual(
+        this.notify.successMsg,
+        t('cyod.registration.saved'),
+        'confirms the change'
+      );
+    });
+
+    test('a failed save rolls the switch back and reports the error', async function (assert) {
+      const { record } = setupOrganization(this, 'cyodEnabled');
+
+      this.server.put('/organizations/:id', () => ({ detail: 'Nope' }), 400);
+
+      await render(TEMPLATE);
+
+      assert.dom(selectors.toggleInput).isChecked();
+
+      await click(selectors.toggleInput);
+
+      assert
+        .dom(selectors.toggleInput)
+        .isChecked('the switch returns to the persisted state');
+
+      assert.true(
+        record.cyodRegistrationEnabled,
+        'the record is not left holding the rejected value'
+      );
+
+      assert.strictEqual(this.notify.errorMsg, 'Nope', 'surfaces the reason');
+    });
+
+    test('it links to the account CYOD settings from the empty state', async function (assert) {
+      setupOrganization(this, 'cyodEnabled');
+
+      await render(TEMPLATE);
+
+      assert.dom(selectors.deviceTableEmpty).exists();
+
+      assert
+        .dom(selectors.goToCyodSettings)
+        .exists('points members at where they can register a device')
+        .hasText(t('cyod.registration.goToCyodSettings'));
+    });
+  }
+);


### PR DESCRIPTION
3/7 in the CYOD stack. Bases on #1713 (cyod-02-account-settings). Merge in order 01→07.

The owner-facing CYOD Registration switch and its device table. Layered under the paid `Feature.cyod` entitlement: the entitlement decides whether an org may use CYOD at all, this decides whether members may currently register their own devices.

Design review applied: title at h5 (16px/700) sharing a centre-aligned row with its toggle, subtext capped at 500px, status chips centred at medium weight.

The component ships here; it is wired into the settings page in 04, which is where the acceptance test lives.

cc @Yibaebi