### PR TITLE
feat(cyod): iOS signing certificates for org and project

### DIFF
--- a/app/components/cyod-device-registration/index.hbs
+++ b/app/components/cyod-device-registration/index.hbs
@@ -31,7 +31,6 @@
       {{else}}
         <AkStack @spacing='1' @alignItems='center'>
           <AkIcon @iconName='warning' @color='warn' />
-
           <AkTypography @color='textSecondary'>
             {{t 'cyod.usbNotSupported'}}
           </AkTypography>
@@ -72,7 +71,6 @@
       @alignItems='center'
     >
       <AkIcon @iconName='info' @color='textSecondary' />
-
       <AkTypography @color='textSecondary'>
         {{t 'cyod.notEnabled'}}
       </AkTypography>

--- a/app/components/organization/settings/index.hbs
+++ b/app/components/organization/settings/index.hbs
@@ -22,6 +22,18 @@
 
   <AkDivider class='my-3' @color='dark' />
 
+  {{#if this.showsDeviceRegistration}}
+    <Organization::DeviceRegistration />
+
+    <AkDivider class='my-3' @color='dark' />
+  {{/if}}
+
+  {{#if this.showsSigningCertificate}}
+    <Organization::SigningCertificate />
+
+    <AkDivider class='my-3' @color='dark' />
+  {{/if}}
+
   <OrganizationArchive />
 
   <AkDivider class='my-3' @color='dark' />

--- a/app/components/organization/settings/index.ts
+++ b/app/components/organization/settings/index.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import type MeService from 'irene/services/me';
+import type OrganizationService from 'irene/services/organization';
 import type { OrganizationSettingsRouteModel } from 'irene/routes/authenticated/dashboard/organization-settings/index';
 
 export interface OrganizationSettingsSignature {
@@ -11,6 +12,19 @@ export interface OrganizationSettingsSignature {
 
 export default class OrganizationSettingsComponent extends Component<OrganizationSettingsSignature> {
   @service declare me: MeService;
+  @service declare organization: OrganizationService;
+
+  get showsDeviceRegistration() {
+    return Boolean(this.me.org?.is_owner && this.organization.isCyodEnabled);
+  }
+
+  // Certificates are part of the CYOD setup, so they collapse with it.
+  get showsSigningCertificate() {
+    return (
+      this.showsDeviceRegistration &&
+      Boolean(this.organization.isCyodRegistrationEnabled)
+    );
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/organization/signing-certificate/index.hbs
+++ b/app/components/organization/signing-certificate/index.hbs
@@ -1,0 +1,622 @@
+{{#if this.visible}}
+  <AkStack
+    data-test-orgSigningCert
+    @width='full'
+    @direction='column'
+    @spacing='1.5'
+    ...attributes
+  >
+    {{#if this.isProjectScope}}
+      <AkTypography @variant='h5' data-test-orgSigningCert-sectionTitle>
+        {{t 'cyod.label'}}
+      </AkTypography>
+    {{/if}}
+
+    <Organization::SettingsPanelHeader
+      @description={{if
+        this.isProjectScope
+        (t 'cyod.signingCert.descProject')
+        (t 'cyod.signingCert.desc')
+      }}
+    >
+      <:title>
+        <AkTypography @variant='h6' data-test-orgSigningCert-title>
+          {{t 'cyod.signingCert.title'}}
+        </AkTypography>
+      </:title>
+
+      <:action>
+        <AkButton
+          data-test-orgSigningCert-openBtn
+          @variant='filled'
+          {{on 'click' this.handleOpen}}
+        >
+          {{t 'cyod.signingCert.add'}}
+        </AkButton>
+      </:action>
+    </Organization::SettingsPanelHeader>
+  </AkStack>
+
+  <AkDrawer
+    @open={{this.showDrawer}}
+    @onClose={{this.handleClose}}
+    @anchor='right'
+    as |dr|
+  >
+    <div data-test-orgSigningCert-drawer local-class='cert-drawer'>
+      <AkAppbar @justifyContent='space-between' as |ab|>
+        {{#if this.pendingDelete}}
+          <AkStack @alignItems='center' @spacing='1.5'>
+            <AkIconButton
+              data-test-orgSigningCert-deleteBackBtn
+              class={{ab.classes.defaultIconBtn}}
+              title={{t 'back'}}
+              {{on 'click' this.cancelDelete}}
+            >
+              <AkIcon @iconName='arrow-back' />
+            </AkIconButton>
+
+            <AkTypography
+              data-test-orgSigningCert-drawerTitle
+              @variant='h5'
+              @color='inherit'
+            >
+              {{t 'confirmation'}}
+            </AkTypography>
+          </AkStack>
+        {{else}}
+          <AkTypography
+            data-test-orgSigningCert-drawerTitle
+            @variant='h5'
+            @color='inherit'
+          >
+            {{t 'cyod.signingCert.add'}}
+          </AkTypography>
+        {{/if}}
+
+        <AkIconButton
+          data-test-orgSigningCert-drawerCloseBtn
+          class={{ab.classes.defaultIconBtn}}
+          {{on 'click' dr.closeHandler}}
+        >
+          <AkIcon @iconName='close' />
+        </AkIconButton>
+      </AkAppbar>
+
+      {{#if this.pendingDelete}}
+        <div local-class='cert-form' data-test-orgSigningCert-deleteConfirm>
+          <AkStack
+            local-class='drawer-body'
+            @direction='column'
+            @spacing='2'
+            @alignItems='stretch'
+            class='py-2 px-4'
+          >
+            <AkStack @direction='column' @spacing='0.5'>
+              <AkTypography data-test-orgSigningCert-deleteConfirmTitle>
+                {{t 'cyod.signingCert.deleteQuestion'}}
+                <strong>
+                  {{if
+                    this.pendingDelete.name
+                    this.pendingDelete.name
+                    (t 'cyod.signingCert.unnamed')
+                  }}?
+                </strong>
+              </AkTypography>
+
+              <AkTypography
+                data-test-orgSigningCert-deleteConfirmInfo
+                @variant='body2'
+                @color='textSecondary'
+              >
+                {{t 'cyod.signingCert.deleteReason'}}
+              </AkTypography>
+            </AkStack>
+
+            <AkStack @spacing='1'>
+              <AkButton
+                data-test-orgSigningCert-deleteCancelBtn
+                @variant='outlined'
+                @color='neutral'
+                @disabled={{this.confirmDelete.isRunning}}
+                {{on 'click' this.cancelDelete}}
+              >
+                {{t 'cyod.signingCert.deleteNo'}}
+              </AkButton>
+
+              <AkButton
+                data-test-orgSigningCert-deleteConfirmBtn
+                @variant='filled'
+                @loading={{this.confirmDelete.isRunning}}
+                {{on 'click' (perform this.confirmDelete)}}
+              >
+                {{t 'yesDelete'}}
+              </AkButton>
+            </AkStack>
+          </AkStack>
+        </div>
+
+      {{else}}
+        <div class='px-4 pt-2'>
+          <AkTabs data-test-orgSigningCert-tabs as |Akt|>
+            <Akt.tabItem
+              data-test-orgSigningCert-addTab
+              @id='add'
+              @buttonVariant={{true}}
+              @isActive={{this.isAddTab}}
+              @onTabClick={{fn this.handleTabChange 'add'}}
+            >
+              {{t 'cyod.signingCert.add'}}
+            </Akt.tabItem>
+
+            <Akt.tabItem
+              data-test-orgSigningCert-existingTab
+              @id='existing'
+              @buttonVariant={{true}}
+              @isActive={{this.isExistingTab}}
+              @onTabClick={{fn this.handleTabChange 'existing'}}
+            >
+              {{t 'cyod.signingCert.existingTab'}}
+            </Akt.tabItem>
+          </AkTabs>
+        </div>
+
+        {{#if this.isAddTab}}
+          <form local-class='cert-form' {{on 'submit' (perform this.upload)}}>
+            <AkStack
+              local-class='drawer-body'
+              @direction='column'
+              @spacing='2.5'
+              @alignItems='stretch'
+              class='py-2 px-4'
+            >
+              <AkStack @width='full' @spacing='2' @alignItems='flex-start'>
+                <div local-class='form-field'>
+                  <AkStack @direction='column' @spacing='1'>
+                    <AkTypography
+                      data-test-orgSigningCert-nameLabel
+                      @variant='subtitle1'
+                      @fontWeight='medium'
+                      @color='textSecondary'
+                      @tag='label'
+                    >
+                      {{t 'cyod.signingCert.name'}}
+                    </AkTypography>
+
+                    <AkTextField
+                      data-test-orgSigningCert-name
+                      aria-label={{t 'cyod.signingCert.name'}}
+                      @placeholder={{t 'cyod.signingCert.namePlaceholder'}}
+                      @value={{this.certName}}
+                      {{on 'input' this.setName}}
+                    />
+                  </AkStack>
+                </div>
+
+                <div local-class='form-field'>
+                  <AkStack @direction='column' @spacing='1'>
+                    <AkTypography
+                      data-test-orgSigningCert-bundleIdLabel
+                      @variant='subtitle1'
+                      @fontWeight='medium'
+                      @color='textSecondary'
+                      @tag='label'
+                    >
+                      {{t 'cyod.signingCert.bundleIdLabel'}}
+                    </AkTypography>
+
+                    <AkTextField
+                      data-test-orgSigningCert-bundleId
+                      aria-label={{t 'cyod.signingCert.bundleIdLabel'}}
+                      @placeholder='com.mfva.myapp'
+                      @value={{this.bundleId}}
+                      {{on 'input' this.setBundleId}}
+                    />
+                  </AkStack>
+                </div>
+              </AkStack>
+
+              <div local-class='tip-callout' data-test-orgSigningCert-tip>
+                <AkTypography local-class='tip-text' @variant='body2'>
+                  <strong>{{t 'cyod.signingCert.tipLabel'}}</strong>
+                  {{t 'cyod.signingCert.bundleIdHint'}}
+                </AkTypography>
+              </div>
+
+              <AkDivider @color='dark' />
+
+              {{! Signing identity (.p12) }}
+              <AkStack @direction='column' @spacing='1'>
+                <AkTypography
+                  @variant='subtitle1'
+                  @fontWeight='medium'
+                  @color='textSecondary'
+                  @tag='label'
+                >
+                  {{t 'cyod.signingCert.p12'}}
+                </AkTypography>
+
+                {{#if this.p12FileName}}
+                  <div local-class='file-chip' data-test-orgSigningCert-p12Chip>
+                    <AkTypography local-class='file-name' @variant='body2'>
+                      {{this.p12FileName}}
+                    </AkTypography>
+
+                    <AkIconButton
+                      data-test-orgSigningCert-p12Clear
+                      @size='small'
+                      title={{t 'remove'}}
+                      {{on 'click' this.clearP12}}
+                    >
+                      <AkIcon @iconName='close' @size='small' />
+                    </AkIconButton>
+                  </div>
+                {{else}}
+                  <AkStack @spacing='1' @alignItems='center'>
+                    <AkButton @tag='label' @variant='outlined'>
+                      <AkIcon @iconName='file-upload' @size='small' />
+
+                      <AkTypography
+                        class='ml-1'
+                        @tag='span'
+                        @variant='subtitle1'
+                        @fontWeight='medium'
+                        @color='inherit'
+                      >
+                        {{t 'chooseFile'}}
+                      </AkTypography>
+
+                      <input
+                        type='file'
+                        accept='.p12,.pfx'
+                        aria-label={{t 'cyod.signingCert.p12'}}
+                        data-test-orgSigningCert-p12
+                        {{style display='none'}}
+                        {{on 'change' this.setP12}}
+                      />
+                    </AkButton>
+
+                    <AkTypography
+                      local-class='file-name'
+                      @variant='body2'
+                      @color='textSecondary'
+                      {{style fontStyle='italic'}}
+                    >
+                      {{t 'noFileChosen'}}
+                    </AkTypography>
+                  </AkStack>
+                {{/if}}
+              </AkStack>
+
+              <div local-class='form-field-half'>
+                <AkStack @direction='column' @spacing='1'>
+                  <AkTypography
+                    data-test-orgSigningCert-passwordLabel
+                    @variant='subtitle1'
+                    @fontWeight='medium'
+                    @color='textSecondary'
+                    @tag='label'
+                  >
+                    {{t 'cyod.signingCert.password'}}
+
+                    <AkTypography
+                      data-test-orgSigningCert-passwordRequired
+                      @tag='span'
+                      @variant='subtitle1'
+                      @fontWeight='medium'
+                      @color='primary'
+                    >
+                      *
+                    </AkTypography>
+                  </AkTypography>
+
+                  <AkTextField
+                    data-test-orgSigningCert-password
+                    aria-label={{t 'cyod.signingCert.password'}}
+                    @placeholder={{t 'enterPassword'}}
+                    @type='password'
+                    @required={{true}}
+                    @value={{this.password}}
+                    autocomplete='new-password'
+                    {{on 'input' this.setPassword}}
+                  />
+                </AkStack>
+              </div>
+
+              <AkDivider @color='dark' />
+
+              {{! Provisioning profile }}
+              <AkStack @direction='column' @spacing='1'>
+                <AkTypography
+                  @variant='subtitle1'
+                  @fontWeight='medium'
+                  @color='textSecondary'
+                  @tag='label'
+                >
+                  {{t 'cyod.signingCert.profile'}}
+                </AkTypography>
+
+                {{#if this.profileFileName}}
+                  <div
+                    local-class='file-chip'
+                    data-test-orgSigningCert-profileChip
+                  >
+                    <AkTypography local-class='file-name' @variant='body2'>
+                      {{this.profileFileName}}
+                    </AkTypography>
+
+                    <AkIconButton
+                      data-test-orgSigningCert-profileClear
+                      @size='small'
+                      title={{t 'remove'}}
+                      {{on 'click' this.clearProfile}}
+                    >
+                      <AkIcon @iconName='close' @size='small' />
+                    </AkIconButton>
+                  </div>
+                {{else}}
+                  <AkStack @spacing='1' @alignItems='center'>
+                    <AkButton @tag='label' @variant='outlined'>
+                      <AkIcon @iconName='file-upload' @size='small' />
+
+                      <AkTypography
+                        class='ml-1'
+                        @tag='span'
+                        @variant='subtitle1'
+                        @fontWeight='medium'
+                        @color='inherit'
+                      >
+                        {{t 'chooseFile'}}
+                      </AkTypography>
+
+                      <input
+                        type='file'
+                        accept='.mobileprovision'
+                        aria-label={{t 'cyod.signingCert.profile'}}
+                        data-test-orgSigningCert-profile
+                        {{style display='none'}}
+                        {{on 'change' this.setProfile}}
+                      />
+                    </AkButton>
+
+                    <AkTypography
+                      local-class='file-name'
+                      @variant='body2'
+                      @color='textSecondary'
+                      {{style fontStyle='italic'}}
+                    >
+                      {{t 'noFileChosen'}}
+                    </AkTypography>
+                  </AkStack>
+                {{/if}}
+              </AkStack>
+            </AkStack>
+
+            <div local-class='drawer-footer'>
+              <AkStack @spacing='1'>
+                <AkButton
+                  data-test-orgSigningCert-uploadBtn
+                  @type='submit'
+                  @variant='filled'
+                  @disabled={{not this.canSave}}
+                  @loading={{this.upload.isRunning}}
+                >
+                  {{t 'save'}}
+                </AkButton>
+
+                <AkButton @variant='outlined' {{on 'click' this.handleClose}}>
+                  {{t 'cancel'}}
+                </AkButton>
+              </AkStack>
+            </div>
+          </form>
+
+        {{else}}
+          {{! ---------------- Existing certificates ---------------- }}
+          <AkStack
+            local-class='drawer-body'
+            @direction='column'
+            @spacing='2'
+            @alignItems='stretch'
+            class='py-2 px-4'
+          >
+            {{#if this.load.isRunning}}
+              <AkStack @spacing='1' @alignItems='center'>
+                <AkLoader @size={{16}} />
+
+                <AkTypography @variant='body2' @color='textSecondary'>
+                  {{t 'loading'}}
+                </AkTypography>
+              </AkStack>
+
+            {{else if this.hasExistingCerts}}
+              {{#each this.existingCerts as |cert|}}
+                <div local-class='cert-card' data-test-orgSigningCert-info>
+                  <AkStack
+                    @alignItems='flex-start'
+                    @justifyContent='space-between'
+                    @spacing='2'
+                  >
+                    <AkStack @direction='column' @spacing='1'>
+                      <AkStack @spacing='1' @alignItems='center'>
+                        <AkTypography
+                          @variant='body1'
+                          @fontWeight='bold'
+                          data-test-orgSigningCert-cardName
+                        >
+                          {{if
+                            cert.name
+                            cert.name
+                            (t 'cyod.signingCert.unnamed')
+                          }}
+                        </AkTypography>
+
+                        {{#if cert.showsActiveBadge}}
+                          <AkChip
+                            data-test-orgSigningCert-activeBadge
+                            @variant='filled'
+                            @size='small'
+                            @color='success'
+                            @label={{t 'activeCapital'}}
+                          />
+                        {{/if}}
+
+                        <AkChip
+                          data-test-orgSigningCert-status
+                          @variant='semi-filled'
+                          @size='small'
+                          @color={{cert.statusColor}}
+                          @label={{if
+                            cert.is_expired
+                            (t 'expired')
+                            (t 'cyod.signingCert.statusValid')
+                          }}
+                        />
+                      </AkStack>
+
+                      <div local-class='cert-meta'>
+                        <AkTypography
+                          local-class='cert-meta-label'
+                          @color='textSecondary'
+                          data-test-orgSigningCert-metaLabel
+                        >
+                          {{t 'team'}}:
+                        </AkTypography>
+
+                        <AkTypography
+                          local-class='cert-meta-value'
+                          data-test-orgSigningCert-metaValue
+                        >
+                          {{cert.team_id}}
+                        </AkTypography>
+
+                        {{#if cert.app_id}}
+                          <AkTypography
+                            local-class='cert-meta-label'
+                            @color='textSecondary'
+                            data-test-orgSigningCert-metaLabel
+                          >
+                            {{t 'cyod.signingCert.appId'}}:
+                          </AkTypography>
+
+                          <AkTypography
+                            local-class='cert-meta-value'
+                            data-test-orgSigningCert-metaValue
+                          >
+                            {{cert.app_id}}
+                          </AkTypography>
+                        {{/if}}
+
+                        <AkTypography
+                          local-class='cert-meta-label'
+                          @color='textSecondary'
+                          data-test-orgSigningCert-metaLabel
+                        >
+                          {{t 'expires'}}:
+                        </AkTypography>
+
+                        <AkTypography
+                          local-class='cert-meta-value'
+                          data-test-orgSigningCert-metaValue
+                          @color={{if cert.is_expired 'error' 'textPrimary'}}
+                        >
+                          {{cert.expiresOn}}
+                        </AkTypography>
+                      </div>
+                    </AkStack>
+
+                    <AkStack @spacing='1' @alignItems='center'>
+                      {{#if cert.showsActivate}}
+                        <AkButton
+                          data-test-orgSigningCert-activateBtn
+                          @variant='outlined'
+                          @color='primary'
+                          @loading={{and
+                            this.activateCert.isRunning
+                            cert.isBusy
+                          }}
+                          {{on 'click' (fn (perform this.activateCert) cert)}}
+                        >
+                          {{t 'cyod.signingCert.makeActive'}}
+                        </AkButton>
+                      {{/if}}
+
+                      {{#if this.isProjectScope}}
+                        <AkIconButton
+                          data-test-orgSigningCert-deleteBtn
+                          @size='small'
+                          title={{t 'delete'}}
+                          {{on 'click' (fn this.requestDelete cert)}}
+                        >
+                          <AkIcon @iconName='delete' @color='textSecondary' />
+                        </AkIconButton>
+                      {{else}}
+                        <AkIconButton
+                          data-test-orgSigningCert-deleteBtn
+                          @size='small'
+                          disabled={{cert.deleteDisabled}}
+                          title={{if
+                            cert.deleteDisabled
+                            (t 'cyod.signingCert.deleteActiveHint')
+                            (t 'delete')
+                          }}
+                          {{on 'click' (fn this.requestDelete cert)}}
+                        >
+                          <AkIcon @iconName='delete' @color='textSecondary' />
+                        </AkIconButton>
+                      {{/if}}
+                    </AkStack>
+                  </AkStack>
+                </div>
+              {{/each}}
+
+            {{else}}
+              <div
+                local-class='empty-state-block'
+                data-test-orgSigningCert-empty
+              >
+                <AkStack
+                  @direction='column'
+                  @alignItems='center'
+                  @justifyContent='center'
+                  @spacing='1'
+                  class='py-7 px-4'
+                >
+                  <AkSvg::ProjectListEmpty
+                    width='155px'
+                    height='63px'
+                    data-test-orgSigningCert-emptySvg
+                  />
+
+                  <AkStack
+                    @direction='column'
+                    @alignItems='center'
+                    @spacing='0.5'
+                  >
+                    <AkTypography
+                      @variant='body1'
+                      @tag='h5'
+                      @fontWeight='medium'
+                      data-test-orgSigningCert-emptyTitle
+                    >
+                      {{t 'cyod.signingCert.noneTitle'}}
+                    </AkTypography>
+
+                    <AkTypography
+                      local-class='empty-description'
+                      @variant='body2'
+                      @align='center'
+                      data-test-orgSigningCert-emptyDescription
+                    >
+                      {{t 'cyod.signingCert.none'}}
+                    </AkTypography>
+                  </AkStack>
+                </AkStack>
+              </div>
+            {{/if}}
+          </AkStack>
+        {{/if}}
+      {{/if}}
+    </div>
+  </AkDrawer>
+{{/if}}

--- a/app/components/organization/signing-certificate/index.scss
+++ b/app/components/organization/signing-certificate/index.scss
@@ -1,0 +1,103 @@
+.cert-drawer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 780px;
+  max-width: 100vw;
+}
+
+.cert-form {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.drawer-footer {
+  margin-top: auto;
+  padding: 1.14286em 1.71429em;
+  border-top: 1px solid var(--organization-signing-certificate-border-color);
+  background: var(--organization-signing-certificate-background);
+}
+
+.cert-meta-label.cert-meta-label {
+  font-size: 0.857rem;
+  font-weight: 500;
+}
+
+.cert-meta-value.cert-meta-value {
+  font-size: 0.857rem;
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.form-field {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.form-field-half.form-field-half {
+  width: calc(50% - 0.5em);
+  min-width: 0;
+}
+
+.tip-callout {
+  padding: 1.14286em;
+  border-left: 4px solid
+    var(--organization-signing-certificate-tip-callout-border-color);
+  border-radius: var(
+    --organization-signing-certificate-tip-callout-border-radius
+  );
+  background: var(--organization-signing-certificate-tip-callout-background);
+}
+
+.tip-text.tip-text {
+  font-size: 0.857rem;
+}
+
+.cert-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 6px;
+  align-items: baseline;
+}
+
+.cert-card {
+  border: 1px solid var(--organization-signing-certificate-border-color);
+  border-radius: var(--organization-signing-certificate-border-radius);
+  background: var(--organization-signing-certificate-background);
+  padding: 1.14286em;
+}
+
+.file-name {
+  word-break: break-all;
+}
+
+.file-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  align-self: flex-start;
+  min-width: 240px;
+  max-width: 100%;
+  padding: 0.42857em 0.57143em 0.42857em 0.85714em;
+  border: 1px solid var(--organization-signing-certificate-border-color);
+  border-radius: var(--organization-signing-certificate-border-radius);
+  background: var(--organization-signing-certificate-background);
+}
+
+.empty-state-block {
+  border: 1px solid var(--organization-signing-certificate-border-color);
+  border-radius: var(--organization-signing-certificate-border-radius);
+}
+
+.empty-description {
+  max-width: 376px;
+}

--- a/app/components/organization/signing-certificate/index.ts
+++ b/app/components/organization/signing-certificate/index.ts
@@ -1,0 +1,383 @@
+/**
+ * iOS Signing Certificate (CYOD dynamic scanning)
+ *
+ * Upload / view / delete the customer iOS signing identity (.p12 + provisioning
+ * profile) used to re-sign an app for dynamic scanning. The secret material is
+ * never returned by the API — only parsed metadata (team id, App ID, expiry,
+ * enrolled UDIDs).
+ *
+ * Scope differs:
+ *  - Organization scope: a **collection** of certs. Exactly one is marked
+ *    `is_active` (the signing fallback). A scan first auto-matches the app's
+ *    bundle id to a cert's App ID, else uses the active cert. The active cert
+ *    cannot be deleted while others exist.
+ *  - Project scope (`@project`): a single cert that overrides the org certs for
+ *    that project's iOS scans.
+ */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import dayjs from 'dayjs';
+import type IntlService from 'ember-intl/services/intl';
+
+import type IreneAjaxService from 'irene/services/ajax';
+import type MeService from 'irene/services/me';
+import type OrganizationService from 'irene/services/organization';
+import type ProjectModel from 'irene/models/project';
+import parseError from 'irene/utils/parse-error';
+import {
+  canManageSigningCertificates,
+  showsProjectSigningCertificate,
+} from 'irene/utils/cyod';
+
+type CertInfo = {
+  id?: number;
+  name?: string;
+  bundle_id?: string;
+  app_id?: string;
+  is_active?: boolean;
+  team_id?: string;
+  provisions_all_devices?: boolean;
+  provisioned_udids?: string[];
+  expires_at?: string | null;
+  is_expired?: boolean;
+};
+
+// A cert decorated by `existingCerts` with everything a row needs to render, so
+// the template does not have to compose `and`/`not`/`eq` per row.
+type CertRow = CertInfo & {
+  expiresOn: string;
+  statusColor: 'error' | 'success';
+  showsActiveBadge: boolean;
+  showsActivate: boolean;
+  isBusy: boolean;
+  deleteDisabled: boolean;
+};
+
+export interface OrganizationSigningCertificateSignature {
+  Element: HTMLDivElement;
+  Args: {
+    // When set, the cert is project-scoped (overrides the org cert for this
+    // project's iOS scans). When absent, it is organization-scoped.
+    project?: ProjectModel;
+  };
+}
+
+export default class OrganizationSigningCertificateComponent extends Component<OrganizationSigningCertificateSignature> {
+  @service declare intl: IntlService;
+  @service declare ajax: IreneAjaxService;
+  @service declare organization: OrganizationService;
+  @service declare me: MeService;
+  @service('notifications') declare notify: NotificationService;
+
+  @tracked showDrawer = false;
+  @tracked activeTab: 'add' | 'existing' = 'add';
+  @tracked cert: CertInfo | null = null;
+  @tracked certs: CertInfo[] = [];
+  @tracked busyCertId: number | null = null;
+  @tracked pendingDelete: CertInfo | null = null;
+
+  @tracked certName = '';
+  @tracked bundleId = '';
+  @tracked password = '';
+  @tracked p12File: File | null = null;
+  @tracked profileFile: File | null = null;
+
+  get baseUrl() {
+    const orgId = this.organization.selected?.id;
+
+    if (this.args.project) {
+      return `/api/organizations/${orgId}/projects/${this.args.project.id}/signing-certificate/`;
+    }
+
+    return `/api/organizations/${orgId}/signing-certificates/`;
+  }
+
+  get isProjectScope() {
+    return !!this.args.project;
+  }
+
+  get canManage() {
+    return canManageSigningCertificates(
+      this.me.org?.is_admin,
+      this.me.org?.is_owner
+    );
+  }
+
+  get visible() {
+    const enabled = this.organization.isCyodRegistrationEnabled;
+
+    if (!this.args.project) {
+      return enabled;
+    }
+
+    return showsProjectSigningCertificate(
+      enabled,
+      this.args.project.platform,
+      this.canManage
+    );
+  }
+
+  get hasCert() {
+    return !!(this.cert && this.cert.team_id);
+  }
+
+  get hasCerts() {
+    return this.certs.length > 0;
+  }
+
+  get p12FileName() {
+    return this.p12File?.name ?? null;
+  }
+
+  get profileFileName() {
+    return this.profileFile?.name ?? null;
+  }
+
+  // Both files and the p12 password are mandatory. The password is trimmed so
+  // whitespace alone does not enable Save.
+  get canSave() {
+    return !!this.p12File && !!this.profileFile && !!this.password.trim();
+  }
+
+  get canActivate() {
+    return !this.isProjectScope;
+  }
+
+  get isAddTab() {
+    return this.activeTab === 'add';
+  }
+
+  get isExistingTab() {
+    return this.activeTab === 'existing';
+  }
+
+  // Project scope holds at most one cert; org scope holds the collection.
+  get scopedCerts(): CertInfo[] {
+    if (!this.isProjectScope) {
+      return this.certs;
+    }
+
+    return this.cert ? [this.cert] : [];
+  }
+
+  get existingCerts(): CertRow[] {
+    return this.scopedCerts.map((cert) => ({
+      ...cert,
+      expiresOn: cert.expires_at
+        ? dayjs(cert.expires_at).format('MMMM D, YYYY, hh:mm A')
+        : '',
+      statusColor: cert.is_expired ? 'error' : 'success',
+      showsActiveBadge: Boolean(cert.is_active) || this.isProjectScope,
+      showsActivate: this.canActivate && !cert.is_active && !cert.is_expired,
+      isBusy: this.busyCertId === cert.id,
+      // The backend refuses to delete the active cert only while siblings
+      // exist — there would be no fallback to promote. A lone cert is deletable
+      // even though it is always the active one, so the org can clear its setup
+      // entirely.
+      deleteDisabled: Boolean(cert.is_active) && this.certs.length > 1,
+    }));
+  }
+
+  get hasExistingCerts() {
+    return this.existingCerts.length > 0;
+  }
+
+  @action
+  handleOpen() {
+    this.activeTab = 'add';
+    this.showDrawer = true;
+    this.load.perform();
+  }
+
+  @action
+  handleClose() {
+    this.resetForm();
+    this.pendingDelete = null;
+    this.showDrawer = false;
+  }
+
+  @action
+  handleTabChange(tab: 'add' | 'existing') {
+    this.activeTab = tab;
+  }
+
+  @action
+  setName(event: Event) {
+    this.certName = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  setBundleId(event: Event) {
+    this.bundleId = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  setPassword(event: Event) {
+    this.password = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  setP12(event: Event) {
+    this.p12File = (event.target as HTMLInputElement).files?.[0] ?? null;
+  }
+
+  @action
+  setProfile(event: Event) {
+    this.profileFile = (event.target as HTMLInputElement).files?.[0] ?? null;
+  }
+
+  @action
+  clearP12() {
+    this.p12File = null;
+  }
+
+  @action
+  clearProfile() {
+    this.profileFile = null;
+  }
+
+  @action
+  resetForm() {
+    this.certName = '';
+    this.bundleId = '';
+    this.password = '';
+    this.p12File = null;
+    this.profileFile = null;
+  }
+
+  @action
+  requestDelete(cert: CertInfo) {
+    this.pendingDelete = cert;
+  }
+
+  @action
+  cancelDelete() {
+    this.pendingDelete = null;
+  }
+
+  load = task(async () => {
+    const orgId = this.organization.selected?.id;
+
+    if (!orgId) {
+      this.cert = null;
+      this.certs = [];
+
+      return;
+    }
+
+    try {
+      if (this.isProjectScope) {
+        const res = await this.ajax.request<CertInfo>(this.baseUrl);
+        this.cert = res && (res.team_id || res.id) ? res : null;
+      } else {
+        const res = await this.ajax.request<CertInfo[]>(this.baseUrl);
+        this.certs = Array.isArray(res) ? res : [];
+      }
+    } catch (e) {
+      this.cert = null;
+      this.certs = [];
+    }
+  });
+
+  upload = task({ restartable: true }, async (event: Event) => {
+    event.preventDefault();
+
+    if (!this.p12File || !this.profileFile) {
+      this.notify.error(this.intl.t('cyod.signingCert.missingFiles'));
+
+      return;
+    }
+
+    try {
+      const formData = new FormData();
+      formData.append('p12', this.p12File);
+      formData.append('password', this.password);
+      formData.append('mobileprovision', this.profileFile);
+      formData.append('name', this.certName);
+      formData.append('bundle_id', this.bundleId.trim());
+
+      await this.ajax.post(this.baseUrl, { data: formData, contentType: null });
+
+      this.notify.success(this.intl.t('cyod.signingCert.uploadSuccess'));
+
+      this.resetForm();
+
+      await this.load.perform();
+    } catch (err) {
+      this.notify.error(parseError(err, this.intl.t('pleaseTryAgain')));
+    }
+  });
+
+  confirmDelete = task({ drop: true }, async () => {
+    const cert = this.pendingDelete;
+
+    if (!cert) {
+      return;
+    }
+
+    if (this.isProjectScope) {
+      await this.deleteCert.perform();
+    } else {
+      await this.deleteOrgCert.perform(cert);
+    }
+
+    this.pendingDelete = null;
+  });
+
+  deleteCert = task({ restartable: true }, async () => {
+    try {
+      await this.ajax.delete(this.baseUrl);
+
+      this.notify.success(this.intl.t('cyod.signingCert.deleted'));
+
+      this.cert = null;
+    } catch (err) {
+      this.notify.error(parseError(err, this.intl.t('pleaseTryAgain')));
+    }
+  });
+
+  // Org scope: delete one cert by id. The backend returns 409 for the active
+  // cert while siblings exist — surfaced as an error toast.
+  deleteOrgCert = task({ restartable: true }, async (cert: CertInfo) => {
+    this.busyCertId = cert.id ?? null;
+
+    try {
+      await this.ajax.delete(`${this.baseUrl}${cert.id}/`);
+
+      this.notify.success(this.intl.t('cyod.signingCert.deleted'));
+
+      await this.load.perform();
+    } catch (err) {
+      this.notify.error(parseError(err, this.intl.t('pleaseTryAgain')));
+    } finally {
+      this.busyCertId = null;
+    }
+  });
+
+  // Org scope: mark one cert active (the backend clears the previous active).
+  activateCert = task({ restartable: true }, async (cert: CertInfo) => {
+    this.busyCertId = cert.id ?? null;
+
+    try {
+      await this.ajax.post(`${this.baseUrl}${cert.id}/activate/`, {});
+
+      this.notify.success(this.intl.t('cyod.signingCert.activated'));
+
+      await this.load.perform();
+    } catch (err) {
+      this.notify.error(parseError(err, this.intl.t('pleaseTryAgain')));
+    } finally {
+      this.busyCertId = null;
+    }
+  });
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Organization::SigningCertificate': typeof OrganizationSigningCertificateComponent;
+    'organization/signing-certificate': typeof OrganizationSigningCertificateComponent;
+  }
+}

--- a/app/components/project-settings/general-settings/index.hbs
+++ b/app/components/project-settings/general-settings/index.hbs
@@ -33,6 +33,17 @@
     </ApiFilter>
   </AkStack>
 
+  {{! Sits directly under the API filter so it is seen without scrolling past
+  Teams and Collaborators. Vertical spacing comes from the wrapper stack, so
+  the section adds no padding of its own. }}
+  {{#if this.showCyodSection}}
+    <AkDivider @color='dark' />
+
+    <AkStack @width='9/12' @direction='column' @spacing='2' class='px-3'>
+      <Organization::SigningCertificate @project={{@project}} />
+    </AkStack>
+  {{/if}}
+
   <AkDivider @color='dark' />
 
   <AkStack @width='9/12' @direction='column' @spacing='2' class='px-3'>

--- a/app/components/project-settings/general-settings/index.ts
+++ b/app/components/project-settings/general-settings/index.ts
@@ -5,9 +5,14 @@ import { task } from 'ember-concurrency';
 import { waitForPromise } from '@ember/test-waiters';
 import type Store from 'ember-data/store';
 
+import {
+  canManageSigningCertificates,
+  showsProjectSigningCertificate,
+} from 'irene/utils/cyod';
 import type ProjectModel from 'irene/models/project';
 import type ProfileModel from 'irene/models/profile';
 import type MeService from 'irene/services/me';
+import type OrganizationService from 'irene/services/organization';
 
 interface ProjectSettingsGeneralSettingsSignature {
   Args: {
@@ -18,6 +23,7 @@ interface ProjectSettingsGeneralSettingsSignature {
 export default class ProjectSettingsGeneralSettingsComponent extends Component<ProjectSettingsGeneralSettingsSignature> {
   @service declare me: MeService;
   @service declare store: Store;
+  @service declare organization: OrganizationService;
 
   @tracked profile: ProfileModel | null = null;
 
@@ -32,6 +38,22 @@ export default class ProjectSettingsGeneralSettingsComponent extends Component<P
 
   get project() {
     return this.args.project;
+  }
+
+  /**
+   * Whether to render the CYOD section and the divider that introduces it.
+   *
+   * The section's divider, width and padding live in this template alongside
+   * where its Teams / Collaborators siblings declare theirs, so this component
+   * decides the divider's visibility — it must go with the section rather than
+   * dangle. Shares one predicate with the panel itself so the two agree.
+   */
+  get showCyodSection() {
+    return showsProjectSigningCertificate(
+      this.organization.isCyodRegistrationEnabled,
+      this.args.project?.platform,
+      canManageSigningCertificates(this.me.org?.is_admin, this.me.org?.is_owner)
+    );
   }
 
   fetchProfile = task(async () => {

--- a/app/styles/_component-variables.scss
+++ b/app/styles/_component-variables.scss
@@ -824,7 +824,9 @@ body {
   );
 
   // variables for sbom/component-inventory/details-drawer
-  --sbom-component-inventory-details-drawer-bom-ref-box-text-color: var(--common-white);
+  --sbom-component-inventory-details-drawer-bom-ref-box-text-color: var(
+    --common-white
+  );
   --sbom-component-inventory-details-drawer-bom-ref-box-background-color: var(
     --common-black
   );
@@ -2589,7 +2591,9 @@ body {
     --neutral-grey-100
   );
 
-  --storeknox-inventory-details-header-app-info-bg-color: var(--background-main);
+  --storeknox-inventory-details-header-app-info-bg-color: var(
+    --background-main
+  );
 
   --storeknox-inventory-details-header-title-container-border-color: var(
     --border-color-1
@@ -2922,16 +2926,32 @@ body {
   );
 
   // variables for storeknox/fake-apps/findings-signal-row
-  --storeknox-fake-apps-findings-signal-row-hover-background-color: var(--background-light);
-  --storeknox-fake-apps-findings-signal-row-result-high-color: var(--severity-critical);
-  --storeknox-fake-apps-findings-signal-row-result-medium-color: var(--severity-high);
-  --storeknox-fake-apps-findings-signal-row-result-low-color: var(--severity-passed);
+  --storeknox-fake-apps-findings-signal-row-hover-background-color: var(
+    --background-light
+  );
+  --storeknox-fake-apps-findings-signal-row-result-high-color: var(
+    --severity-critical
+  );
+  --storeknox-fake-apps-findings-signal-row-result-medium-color: var(
+    --severity-high
+  );
+  --storeknox-fake-apps-findings-signal-row-result-low-color: var(
+    --severity-passed
+  );
 
   // variables for storeknox/fake-apps/signal-detail-drawer
-  --storeknox-fake-apps-signal-detail-drawer-content-border-color: var(--border-color-1);
-  --storeknox-fake-apps-signal-detail-drawer-result-high-color: var(--severity-critical);
-  --storeknox-fake-apps-signal-detail-drawer-result-medium-color: var(--severity-high);
-  --storeknox-fake-apps-signal-detail-drawer-result-low-color: var(--severity-passed);
+  --storeknox-fake-apps-signal-detail-drawer-content-border-color: var(
+    --border-color-1
+  );
+  --storeknox-fake-apps-signal-detail-drawer-result-high-color: var(
+    --severity-critical
+  );
+  --storeknox-fake-apps-signal-detail-drawer-result-medium-color: var(
+    --severity-high
+  );
+  --storeknox-fake-apps-signal-detail-drawer-result-low-color: var(
+    --severity-passed
+  );
 
   // variables for storeknox/fake-apps/ignore-drawer
   --storeknox-fake-apps-ignore-drawer-content-border-color: var(
@@ -3123,6 +3143,20 @@ body {
   // variables for organization/settings-panel-header
   --organization-settings-panel-header-icon-background: var(--primary-light);
   --organization-settings-panel-header-icon-border-radius: var(--border-radius);
+
+  // variables for organization/signing-certificate
+  --organization-signing-certificate-background: var(--common-white);
+  --organization-signing-certificate-border-color: var(--divider-dark);
+  --organization-signing-certificate-border-radius: var(--border-radius-8);
+  --organization-signing-certificate-tip-callout-background: var(
+    --neutral-grey-100
+  );
+  --organization-signing-certificate-tip-callout-border-color: var(
+    --primary-main
+  );
+  --organization-signing-certificate-tip-callout-border-radius: var(
+    --border-radius-4
+  );
 
   // variables for organization/ai-powered-features
   --organization-ai-powered-features-bg-color: var(--common-white);

--- a/app/utils/parse-error.ts
+++ b/app/utils/parse-error.ts
@@ -1,3 +1,29 @@
+/**
+ * Pull the first message out of a DRF field-error body.
+ *
+ * Serializer validation failures arrive keyed by field, with no `detail`:
+ * `{ p12: ['file too large (max 256 KB)'] }`. Without this the caller falls
+ * through to its generic fallback and the user never learns what was wrong.
+ *
+ * Only array-of-string values count, which is the shape DRF produces for field
+ * errors — that keeps an unrelated string field in an error body from being
+ * mistaken for the message.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function firstFieldError(payload: any): string | undefined {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  for (const value of Object.values(payload)) {
+    if (Array.isArray(value) && typeof value[0] === 'string') {
+      return value[0];
+    }
+  }
+
+  return undefined;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function parseError(err: any, defaultMessage?: string) {
   let errMsg = defaultMessage || '';
@@ -23,6 +49,9 @@ export default function parseError(err: any, defaultMessage?: string) {
     errMsg = error.message;
   } else if (error.title) {
     errMsg = error.title;
+  } else {
+    // Checked last so every branch above keeps its existing behaviour.
+    errMsg = firstFieldError(error.payload ?? error) ?? errMsg;
   }
 
   return errMsg;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -105,6 +105,48 @@ function routes() {
     return { count: results.length, next: null, previous: null, results };
   });
 
+  this.get('/organizations/:id/signing-certificates/', (schema) =>
+    schema.signingCertificates.all().models.map((c) => c.toJSON())
+  );
+
+  this.post('/organizations/:id/signing-certificates/', (schema) =>
+    schema.signingCertificates.create({}).toJSON()
+  );
+
+  this.del(
+    '/organizations/:id/signing-certificates/:certId/',
+    (schema, req) => {
+      schema.signingCertificates.find(req.params.certId)?.destroy();
+
+      return {};
+    }
+  );
+
+  this.post(
+    '/organizations/:id/signing-certificates/:certId/activate/',
+    (schema, req) => {
+      schema.signingCertificates.all().models.forEach((c) => {
+        c.update({ is_active: c.id === req.params.certId });
+      });
+
+      return schema.signingCertificates.find(req.params.certId).toJSON();
+    }
+  );
+
+  this.get(
+    '/organizations/:id/projects/:projectId/signing-certificate/',
+    (schema) => schema.signingCertificates.first()?.toJSON() ?? {}
+  );
+
+  this.del(
+    '/organizations/:id/projects/:projectId/signing-certificate/',
+    (schema) => {
+      schema.signingCertificates.first()?.destroy();
+
+      return {};
+    }
+  );
+
   this.put('/organizations/:id', (schema, req) => {
     const organization = schema.organizations.find(req.params.id);
 

--- a/mirage/factories/signing-certificate.ts
+++ b/mirage/factories/signing-certificate.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error "trait" prop missing from miragejs
+import { Factory, trait } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+export default Factory.extend({
+  name: () => `${faker.company.name()} iOS`,
+  team_id: () => faker.string.alphanumeric({ length: 10, casing: 'upper' }),
+  app_id: () => faker.internet.domainName(),
+  bundle_id: () => faker.internet.domainName(),
+  is_active: false,
+  is_expired: false,
+  provisions_all_devices: false,
+  provisioned_udids: () => [],
+  expires_at: () => faker.date.future().toISOString(),
+
+  active: trait({
+    is_active: true,
+  }),
+
+  expired: trait({
+    is_expired: true,
+    expires_at: () => faker.date.past().toISOString(),
+  }),
+
+  enterprise: trait({
+    provisions_all_devices: true,
+  }),
+
+  unnamed: trait({
+    name: null,
+  }),
+});

--- a/mirage/models/signing-certificate.ts
+++ b/mirage/models/signing-certificate.ts
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/tests/acceptance/organization/settings-test.js
+++ b/tests/acceptance/organization/settings-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@ember/test-helpers';
+import { find, visit } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import Service from '@ember/service';
@@ -40,6 +40,20 @@ class NotificationsStub extends Service {
   }
 
   setDefaultAutoClear() {}
+}
+
+/**
+ * The CYOD fields a given organization-factory trait sets, without the rest of
+ * the built record — the suite's organization already exists, so only these
+ * attributes should change.
+ */
+function cyodAttrs(context, trait) {
+  const { features, cyod_registration_enabled } = context.server.build(
+    'organization',
+    trait
+  );
+
+  return { features, cyod_registration_enabled };
 }
 
 module('Acceptance | Organization settings', function (hooks) {
@@ -122,5 +136,65 @@ module('Acceptance | Organization settings', function (hooks) {
     assert
       .dom('[data-test-enable-mandatory-mfa-requirement]')
       .includesText(t('enableMandatoryMFARequirement'));
+  });
+
+  test('it shows the CYOD device registration only when the org has the cyod feature', async function (assert) {
+    this.organizationMe.update({ is_owner: true });
+    this.organization.update(cyodAttrs(this, 'cyodEnabled'));
+
+    await visit('dashboard/organization/settings');
+
+    assert.dom('[data-test-orgDeviceRegistration]').exists();
+    assert.dom('[data-test-orgSigningCert]').exists();
+
+    // The two are separate settings sections, so a rule has to sit between the
+    // devices table and the certificate panel.
+    const registration = find('[data-test-orgDeviceRegistration]');
+    const certificate = find('[data-test-orgSigningCert]');
+
+    const between = [...document.querySelectorAll('[data-test-ak-divider]')]
+      .filter(
+        (hr) =>
+          registration.compareDocumentPosition(hr) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      )
+      .filter(
+        (hr) =>
+          certificate.compareDocumentPosition(hr) &
+          Node.DOCUMENT_POSITION_PRECEDING
+      );
+
+    assert.strictEqual(
+      between.length,
+      1,
+      'exactly one divider separates the devices table from Add Certificate'
+    );
+  });
+
+  test('turning CYOD registration off collapses the certificate section', async function (assert) {
+    this.organizationMe.update({ is_owner: true });
+    this.organization.update(cyodAttrs(this, 'cyodRegistrationDisabled'));
+
+    await visit('dashboard/organization/settings');
+
+    assert
+      .dom('[data-test-orgDeviceRegistration]')
+      .exists('the switch itself stays reachable so it can be turned back on');
+
+    assert
+      .dom('[data-test-orgSigningCert]')
+      .doesNotExist('certificates are part of the CYOD setup');
+  });
+
+  test('it hides the CYOD device registration when the org lacks the cyod feature', async function (assert) {
+    this.organizationMe.update({ is_owner: true });
+    this.organization.update({
+      features: { ...this.organization.features, cyod: false },
+    });
+
+    await visit('dashboard/organization/settings');
+
+    assert.dom('[data-test-orgDeviceRegistration]').doesNotExist();
+    assert.dom('[data-test-orgSigningCert]').doesNotExist();
   });
 });

--- a/tests/integration/components/organization/signing-certificate-test.js
+++ b/tests/integration/components/organization/signing-certificate-test.js
@@ -1,0 +1,675 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn, triggerEvent, find } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+import dayjs from 'dayjs';
+
+import ENUMS from 'irene/enums';
+
+// ─── Stubs ─────────────────────────────────────────────────────────────────────
+class NotificationsStub extends Service {
+  success() {}
+  error() {}
+}
+
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+const selectors = {
+  root: '[data-test-orgSigningCert]',
+  title: '[data-test-orgSigningCert-title]',
+  sectionTitle: '[data-test-orgSigningCert-sectionTitle]',
+  openBtn: '[data-test-orgSigningCert-openBtn]',
+  panelDescription: '[data-test-orgSettingsPanelHeader-description]',
+
+  drawer: '[data-test-orgSigningCert-drawer]',
+  drawerTitle: '[data-test-orgSigningCert-drawerTitle]',
+  drawerCloseBtn: '[data-test-orgSigningCert-drawerCloseBtn]',
+  tabs: '[data-test-orgSigningCert-tabs]',
+  existingTab: '[data-test-orgSigningCert-existingTab] button',
+
+  name: '[data-test-orgSigningCert-name]',
+  bundleId: '[data-test-orgSigningCert-bundleId]',
+  password: '[data-test-orgSigningCert-password]',
+  tip: '[data-test-orgSigningCert-tip]',
+  p12: '[data-test-orgSigningCert-p12]',
+  p12Chip: '[data-test-orgSigningCert-p12Chip]',
+  p12Clear: '[data-test-orgSigningCert-p12Clear]',
+  profileChip: '[data-test-orgSigningCert-profileChip]',
+  profileClear: '[data-test-orgSigningCert-profileClear]',
+  profile: '[data-test-orgSigningCert-profile]',
+  uploadBtn: '[data-test-orgSigningCert-uploadBtn]',
+  divider: '[data-test-ak-divider]',
+
+  info: '[data-test-orgSigningCert-info]',
+  cardName: '[data-test-orgSigningCert-cardName]',
+  metaLabel: '[data-test-orgSigningCert-metaLabel]',
+  metaValue: '[data-test-orgSigningCert-metaValue]',
+  activeBadge: '[data-test-orgSigningCert-activeBadge]',
+  activateBtn: '[data-test-orgSigningCert-activateBtn]',
+  deleteBtn: '[data-test-orgSigningCert-deleteBtn]',
+
+  empty: '[data-test-orgSigningCert-empty]',
+  emptySvg: '[data-test-orgSigningCert-emptySvg]',
+  emptyTitle: '[data-test-orgSigningCert-emptyTitle]',
+  emptyDescription: '[data-test-orgSigningCert-emptyDescription]',
+
+  deleteConfirm: '[data-test-orgSigningCert-deleteConfirm]',
+  deleteConfirmTitle: '[data-test-orgSigningCert-deleteConfirmTitle]',
+  deleteConfirmInfo: '[data-test-orgSigningCert-deleteConfirmInfo]',
+  deleteConfirmBtn: '[data-test-orgSigningCert-deleteConfirmBtn]',
+  deleteCancelBtn: '[data-test-orgSigningCert-deleteCancelBtn]',
+  deleteBackBtn: '[data-test-orgSigningCert-deleteBackBtn]',
+  nameLabel: '[data-test-orgSigningCert-nameLabel]',
+  bundleIdLabel: '[data-test-orgSigningCert-bundleIdLabel]',
+  passwordLabel: '[data-test-orgSigningCert-passwordLabel]',
+  passwordRequired: '[data-test-orgSigningCert-passwordRequired]',
+};
+
+// ─── Templates ─────────────────────────────────────────────────────────────────
+const ORG_SCOPE = hbs`<Organization::SigningCertificate />`;
+const PROJECT_SCOPE = hbs`<Organization::SigningCertificate @project={{this.project}} />`;
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+/**
+ * The drawer opens on the Add tab; the cert list lives behind the second tab.
+ * AkTabs puts the test attribute on the wrapping <li> and the click handler on
+ * the inner <button>, so the button is what has to be clicked.
+ */
+async function openExistingTab() {
+  await click(selectors.openBtn);
+  await click(selectors.existingTab);
+}
+
+/**
+ * Registers a `me` whose org membership carries the given role trait. The panel
+ * is limited to admins and owners, so the role decides whether it renders at all
+ * in project scope.
+ */
+function setupMe(context, ...traits) {
+  const orgMe = context.server.create('organization-me', ...traits);
+
+  class MeStub extends Service {
+    org = orgMe;
+  }
+
+  context.owner.unregister('service:me');
+  context.owner.register('service:me', MeStub);
+
+  return orgMe;
+}
+
+module(
+  'Integration | Component | organization/signing-certificate',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks, 'en');
+    setupMirage(hooks);
+
+    hooks.beforeEach(function () {
+      const organization = this.server.create('organization');
+
+      class OrganizationStub extends Service {
+        selected = organization;
+        isCyodEnabled = true;
+        isCyodRegistrationEnabled = true;
+      }
+
+      this.owner.register('service:organization', OrganizationStub);
+      this.owner.register('service:notifications', NotificationsStub);
+
+      setupMe(this, 'admin');
+
+      this.setProperties({
+        organization,
+        project: this.server.create('project', {
+          platform: ENUMS.PLATFORM.IOS,
+        }),
+      });
+    });
+
+    // ─── Panel ───────────────────────────────────────────────────────────────
+    test('it renders the panel header and add button', async function (assert) {
+      await render(ORG_SCOPE);
+
+      assert.dom(selectors.title).exists();
+      assert.dom(selectors.openBtn).exists();
+      assert.dom(selectors.panelDescription).exists();
+    });
+
+    // ─── Add tab ─────────────────────────────────────────────────────────────
+    test('it opens on the add tab with save disabled', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      assert.dom(selectors.tabs).exists();
+      assert.dom(selectors.p12).exists();
+      assert.dom(selectors.profile).exists();
+      assert.dom(selectors.tip).exists();
+
+      assert
+        .dom(selectors.uploadBtn)
+        .isDisabled('nothing has been supplied yet');
+
+      assert
+        .dom(`${selectors.drawer} ${selectors.divider}`)
+        .exists(
+          { count: 2 },
+          'after the tip, and between the p12 password and the profile'
+        );
+
+      await click(selectors.drawerCloseBtn);
+
+      assert.dom(selectors.drawer).doesNotExist();
+    });
+
+    test('each field carries a label matching the drawer style', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      // The labels are plain AkTypography rather than AkTextField's own @label,
+      // so they render at the same weight as the delete-reason label. The input
+      // keeps its accessible name through aria-label.
+      assert.dom(selectors.nameLabel).hasText(t('cyod.signingCert.name'));
+      assert
+        .dom(selectors.bundleIdLabel)
+        .hasText(t('cyod.signingCert.bundleIdLabel'));
+      // The password label also holds the mandatory-field asterisk, so this is a
+      // containsText rather than an exact match.
+      assert
+        .dom(selectors.passwordLabel)
+        .containsText(t('cyod.signingCert.password'));
+
+      assert.dom(selectors.nameLabel).hasTagName('label');
+
+      // AkTextField spreads ...attributes onto its <Input>, so the test
+      // attribute and aria-label both land on the input itself.
+      assert
+        .dom(selectors.name)
+        .hasAttribute('aria-label', t('cyod.signingCert.name'));
+    });
+
+    test('a chosen file becomes a removable chip', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      assert.dom(selectors.p12Chip).doesNotExist();
+      assert.dom(selectors.p12).exists();
+
+      await triggerEvent(selectors.p12, 'change', {
+        files: [new File(['x'], 'identity.p12')],
+      });
+
+      assert.dom(selectors.p12Chip).containsText('identity.p12');
+
+      assert
+        .dom(selectors.p12)
+        .doesNotExist('the picker is replaced by the chip');
+
+      await click(selectors.p12Clear);
+
+      assert.dom(selectors.p12Chip).doesNotExist();
+      assert.dom(selectors.p12).exists('clearing brings the picker back');
+    });
+
+    test('save unlocks only once both files and the password are supplied', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      await triggerEvent(selectors.p12, 'change', {
+        files: [new File(['x'], 'identity.p12')],
+      });
+
+      await triggerEvent(selectors.profile, 'change', {
+        files: [new File(['x'], 'team.mobileprovision')],
+      });
+
+      assert
+        .dom(selectors.uploadBtn)
+        .isDisabled('both files are chosen, but the p12 password is mandatory');
+
+      await fillIn(selectors.password, '   ');
+
+      assert
+        .dom(selectors.uploadBtn)
+        .isDisabled('whitespace is not a password');
+
+      await fillIn(selectors.password, 'hunter2');
+
+      assert.dom(selectors.uploadBtn).isNotDisabled('all three are supplied');
+
+      await fillIn(selectors.password, '');
+
+      assert
+        .dom(selectors.uploadBtn)
+        .isDisabled('clearing the password locks it again');
+    });
+
+    test('the p12 password is marked mandatory', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      assert.dom(selectors.passwordRequired).hasText('*');
+
+      assert
+        .dom(selectors.password)
+        .hasAttribute(
+          'required',
+          '',
+          'the marker matches the input, so an empty password cannot submit'
+        );
+
+      assert
+        .dom(selectors.nameLabel)
+        .doesNotContainText('*', 'the optional fields carry no marker');
+    });
+
+    test('the provisioning profile picker behaves like the p12 one', async function (assert) {
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      assert.dom(selectors.profileChip).doesNotExist();
+
+      await triggerEvent(selectors.profile, 'change', {
+        files: [new File(['x'], 'team.mobileprovision')],
+      });
+
+      assert.dom(selectors.profileChip).containsText('team.mobileprovision');
+
+      assert
+        .dom(selectors.profile)
+        .doesNotExist('the picker is replaced by the chip');
+
+      await click(selectors.profileClear);
+
+      assert.dom(selectors.profileChip).doesNotExist();
+      assert.dom(selectors.profile).exists('clearing brings the picker back');
+    });
+
+    test('both file inputs are wrapped in a label so the button opens them', async function (assert) {
+      // The inputs are display:none and have no id/for pair — the only thing that
+      // makes "Choose File" open a picker is the enclosing <label>. Rendered as a
+      // <button> instead, the click goes nowhere and the field is unusable.
+      await render(ORG_SCOPE);
+      await click(selectors.openBtn);
+
+      assert.strictEqual(
+        find(selectors.p12).closest('label')?.tagName,
+        'LABEL',
+        'the p12 input is inside a label'
+      );
+
+      assert.strictEqual(
+        find(selectors.profile).closest('label')?.tagName,
+        'LABEL',
+        'the provisioning profile input is inside a label'
+      );
+    });
+
+    // ─── Existing tab ────────────────────────────────────────────────────────
+    test('it shows the empty state on the existing tab when no certificate is configured', async function (assert) {
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      assert.dom(selectors.empty).exists();
+      assert.dom(selectors.info).doesNotExist();
+      assert.dom(selectors.emptySvg).exists();
+
+      assert
+        .dom(selectors.emptyTitle)
+        .hasText(t('cyod.signingCert.noneTitle'))
+        .hasTagName('h5');
+
+      assert
+        .dom(selectors.emptyDescription)
+        .hasText(t('cyod.signingCert.none'));
+    });
+
+    test('it lists org certs and flags the active one', async function (assert) {
+      const active = this.server.create('signing-certificate', 'active');
+      this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      assert.dom(selectors.info).exists({ count: 2 });
+      assert.dom(selectors.activeBadge).exists({ count: 1 });
+      assert.dom(selectors.activateBtn).exists({ count: 1 });
+      assert.dom(selectors.empty).doesNotExist();
+
+      assert.dom(selectors.cardName).hasText(active.name);
+      assert.dom(selectors.metaValue).hasText(active.team_id);
+    });
+
+    test('an expired cert offers no activate button', async function (assert) {
+      this.server.create('signing-certificate', 'active');
+      this.server.create('signing-certificate', 'expired');
+      this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      assert.dom(selectors.info).exists({ count: 3 });
+
+      assert
+        .dom(selectors.activateBtn)
+        .exists(
+          { count: 1 },
+          'neither the active nor the expired cert offers it'
+        );
+    });
+
+    test('it formats the expiry rather than showing the raw timestamp', async function (assert) {
+      const cert = this.server.create('signing-certificate', 'active');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      assert
+        .dom(selectors.info)
+        .doesNotContainText(cert.expires_at, 'no raw ISO string');
+
+      assert
+        .dom(selectors.info)
+        .containsText(dayjs(cert.expires_at).format('MMMM D, YYYY'));
+    });
+
+    test('it disables delete for the active cert while siblings exist', async function (assert) {
+      this.server.create('signing-certificate', 'active');
+      this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      const deleteButtons = this.element.querySelectorAll(selectors.deleteBtn);
+
+      assert.strictEqual(deleteButtons.length, 2);
+
+      assert
+        .dom(deleteButtons[0])
+        .isDisabled('removing the active cert would leave no signing fallback');
+
+      assert
+        .dom(deleteButtons[0])
+        .hasAttribute('title', t('cyod.signingCert.deleteActiveHint'));
+
+      assert.dom(deleteButtons[1]).isNotDisabled();
+    });
+
+    test('a lone active cert can still be deleted', async function (assert) {
+      // Exactly one cert is always active, so gating on is_active alone locked an
+      // org with a single cert out of ever removing it.
+      const cert = this.server.create('signing-certificate', 'active');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+
+      assert.dom(selectors.activeBadge).exists('it is the active cert');
+
+      assert
+        .dom(selectors.deleteBtn)
+        .isNotDisabled('nothing else depends on it, so it can go');
+
+      assert.dom(selectors.deleteBtn).hasAttribute('title', t('delete'));
+
+      await click(selectors.deleteBtn);
+
+      assert
+        .dom(selectors.deleteConfirm)
+        .exists('and the confirmation step is reachable');
+
+      assert.dom(selectors.deleteConfirmTitle).containsText(cert.name);
+    });
+
+    test('it activates a cert via the activate endpoint', async function (assert) {
+      this.server.create('signing-certificate', 'active');
+      const spare = this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+      await click(selectors.activateBtn);
+
+      const activate = this.server.pretender.handledRequests.find((r) =>
+        r.url.includes(`/signing-certificates/${spare.id}/activate/`)
+      );
+
+      assert.ok(activate, 'posts to the activate endpoint for that cert');
+
+      assert.true(spare.reload().is_active, 'the backend marks it active');
+    });
+
+    // ─── Delete confirmation ─────────────────────────────────────────────────
+    test('deleting asks for confirmation before calling the endpoint', async function (assert) {
+      const cert = this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+      await click(selectors.deleteBtn);
+
+      const deletes = () =>
+        this.server.pretender.handledRequests.filter(
+          (r) => r.method === 'DELETE'
+        );
+
+      assert.strictEqual(
+        deletes().length,
+        0,
+        'the trash icon alone deletes nothing'
+      );
+
+      assert.dom(selectors.deleteConfirm).exists();
+      assert.dom(selectors.tabs).doesNotExist();
+
+      assert
+        .dom(selectors.deleteConfirmTitle)
+        .containsText(cert.name, 'names the cert being deleted');
+
+      await click(selectors.deleteCancelBtn);
+
+      assert.strictEqual(deletes().length, 0, 'cancelling deletes nothing');
+      assert.dom(selectors.deleteConfirm).doesNotExist();
+      assert.dom(selectors.tabs).exists('returns to the list');
+
+      await click(selectors.deleteBtn);
+      await click(selectors.deleteConfirmBtn);
+
+      assert.strictEqual(deletes().length, 1, 'confirming runs the delete');
+      assert.dom(selectors.deleteConfirm).doesNotExist();
+    });
+
+    test('the confirmation puts the warning and the actions under the title', async function (assert) {
+      this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+      await click(selectors.deleteBtn);
+
+      const title = find(selectors.deleteConfirmTitle);
+      const info = find(selectors.deleteConfirmInfo);
+
+      assert
+        .dom(info)
+        .hasText(
+          t('cyod.signingCert.deleteReason'),
+          'the consequence of deleting renders as its own line'
+        );
+
+      assert.strictEqual(
+        info.parentElement,
+        title.parentElement,
+        'title and explanation share one block'
+      );
+
+      assert
+        .dom('[data-test-orgSigningCert-deleteReason]')
+        .doesNotExist('the confirmation no longer collects a reason');
+
+      // The actions sit in the scrolling body right under the question rather
+      // than pinned to the drawer footer, so they read as part of the prompt.
+      assert.strictEqual(
+        find(selectors.deleteConfirmBtn).closest(
+          `${selectors.deleteConfirm} > *`
+        ),
+        title.closest(`${selectors.deleteConfirm} > *`),
+        'the actions share the body with the question, not a footer'
+      );
+    });
+
+    test('it deletes the staged cert with a bodyless request', async function (assert) {
+      const cert = this.server.create('signing-certificate');
+      const other = this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+      await click(selectors.deleteBtn);
+      await click(selectors.deleteConfirmBtn);
+
+      const deletes = () =>
+        this.server.pretender.handledRequests.filter(
+          (r) => r.method === 'DELETE'
+        );
+
+      assert.ok(
+        deletes()[0].url.endsWith(
+          `/api/organizations/${this.organization.id}/signing-certificates/${cert.id}/`
+        ),
+        'deletes the cert the confirmation was staged for'
+      );
+
+      assert.notOk(
+        deletes()[0].requestBody,
+        'no reason is collected, so the delete carries no body'
+      );
+
+      await click(selectors.deleteBtn);
+      await click(selectors.deleteConfirmBtn);
+
+      assert.ok(
+        deletes()[1].url.endsWith(
+          `/api/organizations/${this.organization.id}/signing-certificates/${other.id}/`
+        ),
+        'the second confirmation deletes the other cert'
+      );
+    });
+
+    test('the back arrow returns from the confirmation to the list', async function (assert) {
+      this.server.create('signing-certificate');
+
+      await render(ORG_SCOPE);
+      await openExistingTab();
+      await click(selectors.deleteBtn);
+
+      assert.dom(selectors.drawerTitle).hasText(t('confirmation'));
+
+      await click(selectors.deleteBackBtn);
+
+      assert.dom(selectors.deleteConfirm).doesNotExist();
+      assert.dom(selectors.tabs).exists();
+    });
+
+    // ─── Project scope ───────────────────────────────────────────────────────
+    test('project scope shows its single cert with no activate action', async function (assert) {
+      const cert = this.server.create('signing-certificate');
+
+      await render(PROJECT_SCOPE);
+
+      assert
+        .dom(selectors.sectionTitle)
+        .exists('project settings gets the CYOD section heading');
+
+      await openExistingTab();
+
+      assert.dom(selectors.info).exists({ count: 1 });
+      assert.dom(selectors.cardName).hasText(cert.name);
+
+      assert
+        .dom(selectors.activateBtn)
+        .doesNotExist('nothing to switch between in project scope');
+
+      assert.dom(selectors.deleteBtn).exists({ count: 1 });
+    });
+
+    test('it emits no section layout of its own', async function (assert) {
+      await render(PROJECT_SCOPE);
+
+      assert
+        .dom(selectors.divider)
+        .doesNotExist('the caller owns the section divider');
+
+      assert.ok(
+        /ak-typography-h5/.test(find(selectors.sectionTitle).className),
+        'section heading matches its h5 siblings'
+      );
+    });
+
+    // ─── Visibility gates ────────────────────────────────────────────────────
+    test('it hides itself for a non-iOS project', async function (assert) {
+      this.project = this.server.create('project', {
+        platform: ENUMS.PLATFORM.ANDROID,
+      });
+
+      await render(PROJECT_SCOPE);
+
+      assert.dom(selectors.root).doesNotExist();
+      assert.dom(selectors.sectionTitle).doesNotExist();
+    });
+
+    test('project scope is hidden from a plain member', async function (assert) {
+      // The certificate holds the customer's iOS signing identity and the
+      // org-scope panel is owner-only, so the project-scope override must not
+      // become a way for a member to upload or delete one.
+      setupMe(this, 'member');
+
+      await render(PROJECT_SCOPE);
+
+      assert.dom(selectors.root).doesNotExist();
+      assert
+        .dom(selectors.sectionTitle)
+        .doesNotExist('the section heading goes with the panel');
+    });
+
+    test('project scope renders for either management role', async function (assert) {
+      // `is_admin` and `is_owner` are independent flags, so an owner who is not
+      // also flagged admin still gets the panel.
+      setupMe(this, 'owner');
+
+      await render(PROJECT_SCOPE);
+
+      assert.dom(selectors.root).exists('an owner sees it');
+
+      setupMe(this, 'admin');
+
+      await render(PROJECT_SCOPE);
+
+      assert.dom(selectors.root).exists('an admin sees it too');
+    });
+
+    test('it is hidden when the owner turns CYOD registration off', async function (assert) {
+      class OrganizationStub extends Service {
+        selected = this.server?.schema?.organizations?.first();
+        isCyodEnabled = true;
+        isCyodRegistrationEnabled = false;
+      }
+
+      this.owner.register('service:organization', OrganizationStub);
+
+      await render(ORG_SCOPE);
+
+      assert.dom(selectors.root).doesNotExist();
+    });
+
+    test('it is hidden when the CYOD feature is disabled', async function (assert) {
+      class OrganizationStub extends Service {
+        isCyodEnabled = false;
+        isCyodRegistrationEnabled = false;
+      }
+
+      this.owner.register('service:organization', OrganizationStub);
+
+      await render(ORG_SCOPE);
+
+      assert.dom(selectors.root).doesNotExist();
+    });
+  }
+);

--- a/tests/integration/components/project-settings/general-settings/index-test.js
+++ b/tests/integration/components/project-settings/general-settings/index-test.js
@@ -1,0 +1,181 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import ENUMS from 'irene/enums';
+
+class NotificationsStub extends Service {
+  error() {}
+  success() {}
+  info() {}
+}
+
+/**
+ * Registers an organization service whose `selected` is a mirage-created
+ * organization, so the signing-certificate URLs it drives point at a real
+ * record rather than a literal id.
+ */
+/**
+ * Registers a `me` whose org membership carries the given role trait. The CYOD
+ * section is limited to admins and owners, so the role decides whether the
+ * section — and the divider that introduces it — renders at all.
+ */
+function setupMe(context, ...traits) {
+  const orgMe = context.server.create('organization-me', ...traits);
+
+  class MeStub extends Service {
+    org = orgMe;
+  }
+
+  context.owner.unregister('service:me');
+  context.owner.register('service:me', MeStub);
+
+  return orgMe;
+}
+
+function setupOrganization(context, { registrationEnabled = true } = {}) {
+  const organization = context.server.create('organization', 'cyodEnabled');
+
+  class OrganizationStub extends Service {
+    selected = organization;
+    isCyodEnabled = true;
+    isCyodRegistrationEnabled = registrationEnabled;
+  }
+
+  context.owner.unregister('service:organization');
+  context.owner.register('service:organization', OrganizationStub);
+
+  return organization;
+}
+
+module(
+  'Integration | Component | project-settings/general-settings',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+    setupIntl(hooks, 'en');
+
+    hooks.beforeEach(async function () {
+      this.owner.register('service:notifications', NotificationsStub);
+      setupMe(this, 'admin');
+
+      this.server.get('/profiles/:id/proxy_settings', (_, req) => ({
+        id: req.params.id,
+      }));
+
+      this.server.get('/profiles/:id/api_scan_options', (_, req) => ({
+        id: req.params.id,
+      }));
+      this.server.get('/organizations/:id/projects/:pid/teams', () => ({
+        count: 0,
+        next: null,
+        previous: null,
+        results: [],
+      }));
+
+      this.server.get('/projects/:id/collaborators', () => ({
+        count: 0,
+        next: null,
+        previous: null,
+        results: [],
+      }));
+    });
+
+    async function renderFor(context, platform) {
+      const store = context.owner.lookup('service:store');
+      const profile = context.server.create('profile');
+
+      const project = store.push(
+        store.normalize(
+          'project',
+          context.server
+            .create('project', {
+              platform,
+              active_profile_id: profile.id,
+            })
+            .toJSON()
+        )
+      );
+
+      context.set('project', project);
+
+      await render(
+        hbs`<ProjectSettings::GeneralSettings @project={{this.project}} />`
+      );
+    }
+
+    test('an iOS project shows the CYOD section under the API filter', async function (assert) {
+      setupOrganization(this);
+
+      await renderFor(this, ENUMS.PLATFORM.IOS);
+
+      assert.dom('[data-test-orgSigningCert]').exists();
+
+      assert
+        .dom('[data-test-orgSigningCert-sectionTitle]')
+        .hasTagName('h5', 'section heading sits level with Teams');
+
+      // Sections in order: proxy | api filter | CYOD | teams | collaborators.
+      const sections = this.element.querySelectorAll(
+        '[data-test-projectSettings-generalSettings-root] > *'
+      );
+
+      const cyodIndex = [...sections].findIndex((el) =>
+        el.querySelector('[data-test-orgSigningCert]')
+      );
+
+      const teamsIndex = [...sections].findIndex((el) =>
+        el.textContent.includes('Teams')
+      );
+
+      assert.notStrictEqual(cyodIndex, -1, 'CYOD is one of the root sections');
+
+      assert.ok(
+        cyodIndex < teamsIndex,
+        `CYOD (${cyodIndex}) renders above Teams (${teamsIndex})`
+      );
+    });
+
+    test('a plain member gets no CYOD section', async function (assert) {
+      setupOrganization(this);
+      setupMe(this, 'member');
+
+      await renderFor(this, ENUMS.PLATFORM.IOS);
+
+      assert
+        .dom('[data-test-orgSigningCert]')
+        .doesNotExist('signing certificates are an admin/owner surface');
+
+      assert.dom('[data-test-orgSigningCert-sectionTitle]').doesNotExist();
+    });
+
+    // The CYOD divider lives in this template rather than inside the panel, so
+    // hiding the panel without hiding the divider would leave a rule with
+    // nothing under it. Counting dividers is the only way to catch that — the
+    // panel's own tests cannot see a sibling they do not render.
+    test('hiding the CYOD section takes its divider with it', async function (assert) {
+      setupOrganization(this);
+
+      await renderFor(this, ENUMS.PLATFORM.IOS);
+
+      const withCyod = this.element.querySelectorAll(
+        '[data-test-ak-divider]'
+      ).length;
+
+      setupOrganization(this, { registrationEnabled: false });
+
+      await renderFor(this, ENUMS.PLATFORM.IOS);
+
+      assert.dom('[data-test-orgSigningCert]').doesNotExist();
+
+      assert.strictEqual(
+        this.element.querySelectorAll('[data-test-ak-divider]').length,
+        withCyod - 1,
+        'exactly one divider goes with the section — none left dangling'
+      );
+    });
+  }
+);

--- a/tests/unit/utils/parse-error-test.js
+++ b/tests/unit/utils/parse-error-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import parseError from 'irene/utils/parse-error';
+
+module('Unit | Utility | parse-error', function () {
+  module('DRF field errors', function () {
+    test('reads the message out of a field-keyed error body', function (assert) {
+      // What a serializer validation failure looks like: keyed by field, no
+      // `detail`. Before this was handled the caller showed its generic
+      // fallback and the reason was lost.
+      assert.strictEqual(
+        parseError(
+          { payload: { p12: ['file too large (max 256 KB)'] } },
+          'please try again'
+        ),
+        'file too large (max 256 KB)'
+      );
+    });
+
+    test('reads it from the error itself when there is no payload', function (assert) {
+      assert.strictEqual(
+        parseError(
+          { mobileprovision: ['provisioning profile has already expired'] },
+          'please try again'
+        ),
+        'provisioning profile has already expired'
+      );
+    });
+
+    test('falls back when no value is a list of strings', function (assert) {
+      assert.strictEqual(
+        parseError({ payload: { count: 3 } }, 'please try again'),
+        'please try again',
+        'a stray non-error field is not mistaken for the message'
+      );
+    });
+  });
+
+  module('existing shapes are unchanged', function () {
+    test('detail still wins over a field error', function (assert) {
+      assert.strictEqual(
+        parseError(
+          { payload: { detail: 'CYOD is not enabled', p12: ['ignored'] } },
+          'please try again'
+        ),
+        'CYOD is not enabled'
+      );
+    });
+
+    test('message, title and the 500/0 statuses are untouched', function (assert) {
+      assert.strictEqual(
+        parseError({ payload: { message: 'boom' } }, 'fallback'),
+        'boom'
+      );
+
+      assert.strictEqual(parseError({ detail: 'nope' }, 'fallback'), 'nope');
+      assert.strictEqual(parseError({ message: 'bang' }, 'fallback'), 'bang');
+
+      assert.strictEqual(
+        parseError({ status: 500, title: 'Server Error' }, 'fallback'),
+        'Server Error'
+      );
+
+      assert.strictEqual(
+        parseError({ status: 0 }, 'fallback'),
+        'API request failed'
+      );
+    });
+
+    test('the first of an errors array is still used', function (assert) {
+      assert.strictEqual(
+        parseError({ errors: [{ detail: 'first' }, { detail: 'second' }] }),
+        'first'
+      );
+    });
+
+    test('an unrecognised error returns the default', function (assert) {
+      assert.strictEqual(
+        parseError({}, 'please try again'),
+        'please try again'
+      );
+    });
+  });
+});


### PR DESCRIPTION
4/7 in the CYOD stack. Bases on #1714 (cyod-03-org-registration-toggle). Merge in order 01→07.

Org- and project-level iOS signing certificates: the add-certificate drawer, the existing-certificates tab, and delete confirmation. Also wires both this and 03's toggle into the organization settings page.

Design review applied: `py-2 px-4` drawer body, dark dividers, tip callout at 4px radius on a 4px accent bar, medium input labels, italic "No file chosen", selected files as removable chips, and the certificate card ramp from the Figma frames (name 700, meta labels 12px/500, values 12px/600).

cc @Yibaebi — the delete dialog and the card ramp are the two worth a close look.