### PR TITLE
feat(cyod): CYOD device viewer and WebUSB auto-install

### DIFF
--- a/app/components/cyod-viewer/index.hbs
+++ b/app/components/cyod-viewer/index.hbs
@@ -1,0 +1,42 @@
+<div data-test-cyodViewer local-class='cyod-viewer-root' ...attributes>
+  {{#if this.errorMessage}}
+    <AkStack
+      data-test-cyodViewer-error
+      @direction='column'
+      @alignItems='center'
+      @spacing='1'
+    >
+      <AkIcon @iconName='warning' @color='warn' />
+
+      <AkTypography @color='textSecondary'>{{this.errorMessage}}</AkTypography>
+    </AkStack>
+  {{else}}
+    {{#unless this.isConnected}}
+      <AkStack
+        data-test-cyodViewer-connecting
+        @direction='column'
+        @alignItems='center'
+        @spacing='1'
+      >
+        <AkLoader @size={{24}} />
+
+        <AkTypography @color='textSecondary'>
+          {{t 'cyod.detectingDevice'}}
+        </AkTypography>
+      </AkStack>
+    {{/unless}}
+
+    {{! Remote input, not a click target: a drag needs down/move/up as they happen. }}
+    {{! template-lint-disable no-pointer-down-event-binding }}
+    <canvas
+      data-test-cyodViewer-canvas
+      local-class='cyod-canvas {{unless this.isConnected "hidden"}}'
+      {{this.setupCanvas}}
+      {{on 'pointerdown' this.handlePointerDown}}
+      {{on 'pointermove' this.handlePointerMove}}
+      {{on 'pointerup' this.handlePointerUp}}
+      {{on 'pointercancel' this.handlePointerCancel}}
+      {{on 'pointerleave' this.handlePointerCancel}}
+    />
+  {{/if}}
+</div>

--- a/app/components/cyod-viewer/index.scss
+++ b/app/components/cyod-viewer/index.scss
@@ -1,0 +1,20 @@
+.cyod-viewer-root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.cyod-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: pointer;
+
+  &.hidden {
+    display: none;
+  }
+}

--- a/app/components/cyod-viewer/index.ts
+++ b/app/components/cyod-viewer/index.ts
@@ -1,0 +1,296 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+import type IntlService from 'ember-intl/services/intl';
+
+import type DevicefarmService from 'irene/services/devicefarm';
+import type LoggerService from 'irene/services/logger';
+
+const SCRCPY_WS_PATH = '/devicefarm/ws/scrcpy/';
+
+export interface CyodViewerSignature {
+  Args: {
+    scanToken: string;
+    platform: number;
+    authToken: string;
+  };
+  Element: HTMLDivElement;
+}
+
+export default class CyodViewerComponent extends Component<CyodViewerSignature> {
+  @service declare intl: IntlService;
+  @service declare devicefarm: DevicefarmService;
+  @service declare logger: LoggerService;
+
+  @tracked isConnected = false;
+  @tracked errorMessage: string | null = null;
+
+  private ws: WebSocket | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private videoDecoder: VideoDecoder | null = null;
+  private isPointerDown = false;
+  private spsBuffer: Uint8Array | null = null;
+  private hasReceivedKeyFrame = false;
+
+  get wsUrl() {
+    const base = this.devicefarm.urlbase.replace(/^http/, 'ws');
+    const url = new URL(`${SCRCPY_WS_PATH}${this.args.scanToken}/`, base);
+    url.searchParams.set('token', this.args.authToken);
+
+    return url.href;
+  }
+
+  setupCanvas = modifier((canvas: HTMLCanvasElement) => {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.connect();
+
+    return () => {
+      this.disconnect();
+    };
+  });
+
+  @action
+  handlePointerDown(event: PointerEvent) {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.isPointerDown = true;
+    this.sendTouch('down', event);
+  }
+
+  @action
+  handlePointerMove(event: PointerEvent) {
+    if (!this.isPointerDown || !this.canvas) {
+      return;
+    }
+
+    this.sendTouch('move', event);
+  }
+
+  @action
+  handlePointerUp(event: PointerEvent) {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.isPointerDown = false;
+    this.sendTouch('up', event);
+  }
+
+  @action
+  handlePointerCancel(event: PointerEvent) {
+    if (!this.isPointerDown) {
+      return;
+    }
+
+    this.isPointerDown = false;
+    this.sendTouch('up', event);
+  }
+
+  private sendTouch(action: string, event: PointerEvent) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.canvas) {
+      return;
+    }
+
+    const rect = this.canvas.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+    this.ws.send(JSON.stringify({ type: 'touch', action, x, y }));
+  }
+
+  private connect() {
+    if (this.ws) {
+      return;
+    }
+    if (!this.args.scanToken) {
+      return;
+    }
+
+    this.errorMessage = null;
+
+    this.ws = new WebSocket(this.wsUrl);
+    this.ws.binaryType = 'arraybuffer';
+
+    this.ws.onopen = () => {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.isConnected = true;
+      this.initH264Decoder();
+    };
+
+    this.ws.onclose = () => {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.isConnected = false;
+      this.cleanupDecoder();
+    };
+
+    this.ws.onerror = () => {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.errorMessage = this.intl.t('cyod.viewer.connectionFailed');
+      this.isConnected = false;
+    };
+
+    this.ws.onmessage = (event: MessageEvent) => {
+      if (event.data instanceof ArrayBuffer) {
+        this.decodeH264Frame(new Uint8Array(event.data));
+      }
+    };
+  }
+
+  private disconnect() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    this.cleanupDecoder();
+    this.isConnected = false;
+  }
+
+  private initH264Decoder(codec = 'avc1.42001f') {
+    if (!('VideoDecoder' in window)) {
+      this.errorMessage = this.intl.t('cyod.viewer.unsupportedBrowser');
+
+      return;
+    }
+
+    if (this.videoDecoder && this.videoDecoder.state !== 'closed') {
+      this.videoDecoder.close();
+    }
+
+    this.hasReceivedKeyFrame = false;
+
+    this.videoDecoder = new VideoDecoder({
+      output: (frame: VideoFrame) => {
+        if (this.ctx && this.canvas) {
+          this.canvas.width = frame.displayWidth;
+          this.canvas.height = frame.displayHeight;
+          this.ctx.drawImage(frame, 0, 0);
+        }
+        frame.close();
+      },
+      error: (err: Error) => {
+        this.logger.error('[CyodViewer] H.264 decode error:', err);
+      },
+    });
+
+    this.videoDecoder.configure({ codec, optimizeForLatency: true });
+  }
+
+  private hasNalType(bytes: Uint8Array, type: number): boolean {
+    for (let i = 0; i < bytes.length - 4; i++) {
+      if (
+        bytes[i] === 0 &&
+        bytes[i + 1] === 0 &&
+        bytes[i + 2] === 0 &&
+        bytes[i + 3] === 1 &&
+        (bytes[i + 4]! & 0x1f) === type
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private decodeH264Frame(bytes: Uint8Array) {
+    if (!this.videoDecoder || this.videoDecoder.state === 'closed') {
+      return;
+    }
+    if (bytes.length <= 4) {
+      return;
+    }
+
+    const firstNalType = bytes[4]! & 0x1f;
+    const isSps = firstNalType === 7;
+    const isIdr = firstNalType === 5 || this.hasNalType(bytes, 5);
+
+    if (isSps) {
+      if (bytes.length > 7) {
+        const profile = bytes[5]!.toString(16).padStart(2, '0');
+        const constraints = bytes[6]!.toString(16).padStart(2, '0');
+        const level = bytes[7]!.toString(16).padStart(2, '0');
+        const codec = `avc1.${profile}${constraints}${level}`;
+        this.initH264Decoder(codec);
+        const decoder = this.videoDecoder;
+        if (!decoder || decoder.state === 'closed') {
+          return;
+        }
+      }
+      this.spsBuffer = bytes;
+
+      if (this.hasNalType(bytes, 5)) {
+        this.submitVideoChunk(bytes, 'key');
+      }
+
+      // Submitting SPS/PPS alone errors the decoder — it is not a picture frame.
+      return;
+    }
+
+    if (isIdr) {
+      // Scrcpy sends config and IDR separately; the decoder needs the parameter
+      // sets first, so prepend them.
+      let frameData = bytes;
+      if (this.spsBuffer) {
+        const combined = new Uint8Array(this.spsBuffer.length + bytes.length);
+        combined.set(this.spsBuffer);
+        combined.set(bytes, this.spsBuffer.length);
+        frameData = combined;
+      }
+      this.submitVideoChunk(frameData, 'key');
+      this.hasReceivedKeyFrame = true;
+
+      return;
+    }
+
+    if (!this.hasReceivedKeyFrame) {
+      return;
+    }
+
+    this.submitVideoChunk(bytes, 'delta');
+  }
+
+  private submitVideoChunk(bytes: Uint8Array, type: 'key' | 'delta') {
+    if (!this.videoDecoder || this.videoDecoder.state === 'closed') {
+      return;
+    }
+    try {
+      this.videoDecoder.decode(
+        new EncodedVideoChunk({
+          type,
+          timestamp: performance.now() * 1000,
+          data: bytes,
+        })
+      );
+    } catch (err) {
+      this.logger.error('[CyodViewer] decode() threw:', err);
+    }
+  }
+
+  private cleanupDecoder() {
+    if (this.videoDecoder && this.videoDecoder.state !== 'closed') {
+      this.videoDecoder.close();
+      this.videoDecoder = null;
+    }
+
+    this.spsBuffer = null;
+    this.hasReceivedKeyFrame = false;
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    CyodViewer: typeof CyodViewerComponent;
+    'cyod-viewer': typeof CyodViewerComponent;
+  }
+}

--- a/app/components/vnc-viewer/automated-scan-note/index.hbs
+++ b/app/components/vnc-viewer/automated-scan-note/index.hbs
@@ -1,0 +1,15 @@
+<AkStack
+  data-test-vncViewer-automatedNote
+  local-class='automated-scan-vnc-note'
+  ...attributes
+>
+  <AkTypography @color='inherit'>
+    <strong>{{t 'note'}}</strong>
+    -
+    {{if
+      @dynamicScan.isInqueue
+      (t 'automatedScanQueuedVncNote')
+      (t 'automatedScanRunningVncNote')
+    }}
+  </AkTypography>
+</AkStack>

--- a/app/components/vnc-viewer/automated-scan-note/index.scss
+++ b/app/components/vnc-viewer/automated-scan-note/index.scss
@@ -1,0 +1,7 @@
+.automated-scan-vnc-note {
+  background-color: var(--vnc-viewer-automated-scan-note-background);
+  color: var(--vnc-viewer-automated-scan-note-text-color);
+  padding: 1em;
+  margin: 6em 1em;
+  border-radius: var(--vnc-viewer-automated-scan-note-border-radius);
+}

--- a/app/components/vnc-viewer/cyod-download-link/index.hbs
+++ b/app/components/vnc-viewer/cyod-download-link/index.hbs
@@ -1,0 +1,15 @@
+{{#if @url}}
+  <AkButton
+    data-test-vncViewer-cyodDownloadLink
+    @tag='a'
+    @variant='text'
+    @color='primary'
+    @underline='always'
+    href={{@url}}
+    target='_blank'
+    rel='noopener noreferrer'
+    ...attributes
+  >
+    {{if @isIos (t 'cyod.installIos') (t 'cyod.downloadApk')}}
+  </AkButton>
+{{/if}}

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -58,7 +58,123 @@
     {{/if}}
   {{/if}}
 
-  {{#if this.supportsModernIOSDeviceFrame}}
+  {{#if (or this.isCyodScan this.isScrcpyScan)}}
+    <div data-test-vncViewer-device class='marvel-device {{this.deviceType}}'>
+      {{#if this.isTablet}}
+        <div data-test-vncViewer-deviceTopBar class='top-bar' />
+
+        <div data-test-vncViewer-deviceSleep class='sleep' />
+
+        <div data-test-vncViewer-deviceVolume class='volume' />
+      {{/if}}
+
+      <div data-test-vncViewer-deviceCamera class='camera' />
+
+      {{#if this.isIOSDevice}}
+        {{#if this.isTablet}}
+          <div data-test-vncViewer-deviceSpeaker class='speaker' />
+        {{/if}}
+      {{/if}}
+
+      <div data-test-vncViewer-deviceScreen class='screen'>
+        {{#if (and this.isCyodScan @dynamicScan.isInstalling)}}
+          {{#if this.isWebusbCyod}}
+            <AkStack
+              data-test-vncViewer-webusbInstall
+              local-class='cyod-install-note'
+              @direction='column'
+              @alignItems='center'
+              @spacing='1'
+            >
+              {{#if this.webusbInstallIsRunning}}
+                <AkTypography @color='inherit' @variant='subtitle2'>
+                  {{#if (eq this.webusbInstallStage 'downloading')}}
+                    {{t 'cyod.autoInstall.downloading'}}
+                    ({{this.webusbInstallPercent}}%)
+                  {{else if (eq this.webusbInstallStage 'pushing')}}
+                    {{t 'cyod.autoInstall.pushing'}}
+                    ({{this.webusbInstallPercent}}%)
+                  {{else if (eq this.webusbInstallStage 'installing')}}
+                    {{t 'cyod.autoInstall.installing'}}
+                  {{else}}
+                    {{t 'cyod.autoInstall.done'}}
+                  {{/if}}
+                </AkTypography>
+              {{else if this.webusbAdb}}
+                <AkTypography @color='inherit' @variant='subtitle2'>
+                  {{t 'cyod.autoInstall.ready'}}
+                </AkTypography>
+
+                <AkButton
+                  data-test-vncViewer-webusbInstallBtn
+                  @variant='contained'
+                  @size='small'
+                  {{on 'click' (perform this.autoInstallViaWebUsb)}}
+                >
+                  {{t 'cyod.autoInstall.start'}}
+                </AkButton>
+              {{else}}
+                <AkTypography @color='inherit' @variant='subtitle2'>
+                  {{t 'cyod.installApp'}}
+                </AkTypography>
+
+                <VncViewer::CyodDownloadLink
+                  @url={{this.cyodDownloadUrl}}
+                  @isIos={{false}}
+                />
+              {{/if}}
+            </AkStack>
+          {{else}}
+            <AkStack
+              data-test-vncViewer-cyodDownload
+              local-class='cyod-install-note'
+              @direction='column'
+              @alignItems='center'
+              @spacing='1'
+            >
+              <AkTypography @color='inherit' @variant='subtitle2'>
+                {{t 'cyod.installApp'}}
+              </AkTypography>
+
+              <VncViewer::CyodDownloadLink
+                @url={{this.cyodDownloadUrl}}
+                @isIos={{this.cyodIsIos}}
+              />
+            </AkStack>
+          {{/if}}
+        {{else if this.isScrcpyScan}}
+          <CyodViewer
+            data-test-vncViewer-cyodViewer
+            @scanToken={{this.scrcpyScanToken}}
+            @platform={{this.filePlatform}}
+            @authToken={{this.cyodAuthToken}}
+          />
+        {{else if (and this.isCyodScan @dynamicScan.isReady)}}
+          <AkStack
+            data-test-vncViewer-cyodReady
+            local-class='cyod-ready-note'
+            @direction='column'
+            @alignItems='center'
+            @spacing='1'
+          >
+            <AkIcon @iconName='smartphone' @color='inherit' />
+
+            <AkTypography @color='inherit' @variant='subtitle2'>
+              {{t 'cyod.interactOnDevice'}}
+            </AkTypography>
+          </AkStack>
+        {{/if}}
+      </div>
+
+      {{#if this.isIOSDevice}}
+        <div data-test-vncViewer-deviceHome class='home' />
+
+        {{#if this.isTablet}}
+          <div data-test-vncViewer-deviceBottomBar class='bottom-bar' />
+        {{/if}}
+      {{/if}}
+    </div>
+  {{else if this.supportsModernIOSDeviceFrame}}
     <div data-test-vncViewer-device class='ios-device-frame'>
       <div data-test-vncViewer-deviceScreen class='ios-device-screen'>
         {{#if this.isAutomatedAndScheduledInternally}}
@@ -68,22 +184,7 @@
               @dynamicScan.isReadyOrRunning
             )
           }}
-            <AkStack
-              data-test-vncViewer-automatedNote
-              local-class='automated-scan-vnc-note'
-            >
-              <AkTypography @color='inherit'>
-                <strong>{{t 'note'}}</strong>
-                -
-                {{t
-                  (if
-                    @dynamicScan.isInqueue
-                    'automatedScanQueuedVncNote'
-                    'automatedScanRunningVncNote'
-                  )
-                }}
-              </AkTypography>
-            </AkStack>
+            <VncViewer::AutomatedScanNote @dynamicScan={{@dynamicScan}} />
           {{/if}}
         {{else if @dynamicScan.isReadyOrRunning}}
           <NovncRfb
@@ -99,7 +200,9 @@
     <div data-test-vncViewer-device class='marvel-device {{this.deviceType}}'>
       {{#if this.isTablet}}
         <div data-test-vncViewer-deviceTopBar class='top-bar' />
+
         <div data-test-vncViewer-deviceSleep class='sleep' />
+
         <div data-test-vncViewer-deviceVolume class='volume' />
       {{/if}}
 
@@ -119,22 +222,7 @@
               @dynamicScan.isReadyOrRunning
             )
           }}
-            <AkStack
-              data-test-vncViewer-automatedNote
-              local-class='automated-scan-vnc-note'
-            >
-              <AkTypography @color='inherit'>
-                <strong>{{t 'note'}}</strong>
-                -
-                {{t
-                  (if
-                    @dynamicScan.isInqueue
-                    'automatedScanQueuedVncNote'
-                    'automatedScanRunningVncNote'
-                  )
-                }}
-              </AkTypography>
-            </AkStack>
+            <VncViewer::AutomatedScanNote @dynamicScan={{@dynamicScan}} />
           {{/if}}
         {{else if @dynamicScan.isReadyOrRunning}}
           <NovncRfb

--- a/app/components/vnc-viewer/index.scss
+++ b/app/components/vnc-viewer/index.scss
@@ -1,14 +1,6 @@
-.automated-scan-vnc-note {
-  background-color: var(--vnc-viewer-note-background);
-  color: var(--vnc-viewer-note-text-color);
-  padding: 1em;
-  margin: 6em 1em;
-  border-radius: var(--vnc-viewer-note-border-radius);
-}
-
 .automated-scan-trigger-info {
   padding: 1em;
   background-color: var(--vnc-viewer-info-background);
-  border-radius: var(--vnc-viewer-note-border-radius);
+  border-radius: var(--vnc-viewer-info-border-radius);
   border: 1px solid var(--vnc-viewer-info-border-color);
 }

--- a/app/components/vnc-viewer/index.ts
+++ b/app/components/vnc-viewer/index.ts
@@ -1,17 +1,22 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
 import type Store from 'ember-data/store';
 import type IntlService from 'ember-intl/services/intl';
 
 import ENUMS from 'irene/enums';
 import ENV from 'irene/config/environment';
-import type FileModel from 'irene/models/file';
-import type DynamicscanModel from 'irene/models/dynamicscan';
-import type DevicefarmService from 'irene/services/devicefarm';
 import {
   IOS_MODERN_DEVICE_VERSION_CUTOFF,
   getPlatformMajorVersion,
 } from 'irene/utils/dynamic-scan-device';
+import { resolveFileProject } from 'irene/utils/resolve-file-project';
+import type FileModel from 'irene/models/file';
+import type ProjectModel from 'irene/models/project';
+import type DynamicscanModel from 'irene/models/dynamicscan';
+import type DevicefarmService from 'irene/services/devicefarm';
+import type CyodAdbSessionService from 'irene/services/cyod-adb-session';
 
 export interface VncViewerSignature {
   Args: {
@@ -29,6 +34,26 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
   @service declare intl: IntlService;
   @service declare store: Store;
   @service declare devicefarm: DevicefarmService;
+  @service('cyod-adb-session') declare cyodAdbSession: CyodAdbSessionService;
+  @service('notifications') declare notify: NotificationService;
+
+  @tracked webusbInstallStage: string | null = null;
+  @tracked webusbInstallPercent = 0;
+  @tracked resolvedProject: ProjectModel | null = null;
+
+  constructor(owner: unknown, args: VncViewerSignature['Args']) {
+    super(owner, args);
+
+    this.loadProject.perform();
+  }
+
+  get filePlatform(): number {
+    const project =
+      (this.args.file.belongsTo('project').value() as ProjectModel | null) ??
+      this.resolvedProject;
+
+    return project?.platform ?? -1;
+  }
 
   get dynamicScan() {
     return this.args.dynamicScan;
@@ -74,8 +99,12 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
     return this.supportsModernIOSDeviceFrame ? null : ENV.deviceFarmPassword;
   }
 
+  get cyodAuthToken() {
+    return ENV.deviceFarmPassword;
+  }
+
   get deviceType() {
-    const platform = this.args.file.project.get('platform');
+    const platform = this.filePlatform;
 
     if (platform === ENUMS.PLATFORM.ANDROID) {
       return 'nexus5';
@@ -104,14 +133,103 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
   }
 
   get isIOSDevice() {
-    const platform = this.args.file.project.get('platform');
-
-    return platform === ENUMS.PLATFORM.IOS;
+    return this.filePlatform === ENUMS.PLATFORM.IOS;
   }
 
   get startedBy() {
     return this.dynamicScan?.get('startedByUser')?.get('username');
   }
+
+  get isCyodScan() {
+    const deviceUsed = this.args.dynamicScan?.get('deviceUsed');
+
+    return (
+      deviceUsed?.vnc_mode === ENUMS.DEVICE_VNC_MODE.NONE ||
+      !!deviceUsed?.ios_itms_url ||
+      !!deviceUsed?.android_download_url
+    );
+  }
+
+  get cyodDownloadUrl() {
+    const deviceUsed = this.args.dynamicScan?.get('deviceUsed');
+
+    return deviceUsed?.android_download_url ?? deviceUsed?.ios_itms_url ?? null;
+  }
+
+  get cyodIsIos() {
+    const deviceUsed = this.args.dynamicScan?.get('deviceUsed');
+
+    return !!deviceUsed?.ios_itms_url;
+  }
+
+  get isWebusbCyod() {
+    const deviceUsed = this.args.dynamicScan?.get('deviceUsed');
+
+    return (
+      !!deviceUsed?.android_download_url &&
+      deviceUsed?.registration_source ===
+        ENUMS.DEVICE_REGISTRATION_SOURCE.WEBUSB &&
+      !!deviceUsed?.device_identifier
+    );
+  }
+
+  get webusbAdb() {
+    const identifier =
+      this.args.dynamicScan?.get('deviceUsed')?.device_identifier;
+
+    return identifier ? this.cyodAdbSession.lookup(identifier) : null;
+  }
+
+  get webusbInstallIsRunning() {
+    return this.autoInstallViaWebUsb.isRunning;
+  }
+
+  get isScrcpyScan() {
+    const deviceUsed = this.args.dynamicScan?.get('deviceUsed');
+
+    return deviceUsed?.vnc_mode === ENUMS.DEVICE_VNC_MODE.SCRCPY;
+  }
+
+  get scrcpyScanToken() {
+    return this.args.dynamicScan?.get('moriartyDynamicscanToken') ?? null;
+  }
+
+  loadProject = task(async () => {
+    this.resolvedProject = await resolveFileProject(this.args.file, this.store);
+  });
+
+  autoInstallViaWebUsb = task(async () => {
+    const adb = this.webusbAdb;
+    const downloadUrl = this.cyodDownloadUrl;
+    const packageName = this.args.dynamicScan?.get('packageName');
+
+    if (!adb || !downloadUrl || !packageName) {
+      return;
+    }
+
+    try {
+      const { installApkViaWebUsb, launchAppViaWebUsb } = await import(
+        'irene/utils/webusb-adb-install'
+      );
+
+      await installApkViaWebUsb(adb, downloadUrl, packageName, {
+        onProgress: (progress) => {
+          this.webusbInstallStage = progress.stage;
+
+          if ('percent' in progress) {
+            this.webusbInstallPercent = progress.percent;
+          }
+        },
+      });
+
+      await launchAppViaWebUsb(adb, packageName);
+
+      this.webusbInstallStage = 'done';
+    } catch (err) {
+      this.notify.error(this.intl.t('cyod.autoInstall.failed'));
+      throw err;
+    }
+  });
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/services/cyod-adb-session.ts
+++ b/app/services/cyod-adb-session.ts
@@ -1,0 +1,70 @@
+import Service from '@ember/service';
+import type { Adb } from '@yume-chan/adb';
+
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+type SessionEntry = {
+  adb: Adb;
+  serial: string;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export default class CyodAdbSessionService extends Service {
+  private sessions = new Map<string, SessionEntry>();
+
+  store(serial: string, adb: Adb): void {
+    this.evict(serial);
+
+    const timer = setTimeout(() => {
+      this.evict(serial);
+    }, TTL_MS);
+
+    this.sessions.set(serial, { adb, serial, timer });
+  }
+
+  lookup(serial: string): Adb | null {
+    const entry = this.sessions.get(serial);
+    if (!entry) {
+      return null;
+    }
+
+    clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => {
+      this.evict(serial);
+    }, TTL_MS);
+
+    return entry.adb;
+  }
+
+  release(serial: string): void {
+    this.evict(serial);
+  }
+
+  override willDestroy(): void {
+    for (const serial of this.sessions.keys()) {
+      this.evict(serial);
+    }
+    super.willDestroy();
+  }
+
+  private evict(serial: string): void {
+    const entry = this.sessions.get(serial);
+    if (!entry) {
+      return;
+    }
+
+    clearTimeout(entry.timer);
+    try {
+      entry.adb.close();
+    } catch {
+      // the handle is being dropped either way
+    }
+    this.sessions.delete(serial);
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'cyod-adb-session': CyodAdbSessionService;
+  }
+}

--- a/app/styles/_component-variables.scss
+++ b/app/styles/_component-variables.scss
@@ -1516,11 +1516,14 @@ body {
   );
   --vnc-viewer-modal-background: var(--background-main);
   --vnc-viewer-modal-text-color: var(--text-primary);
-  --vnc-viewer-note-border-radius: var(--border-radius);
-  --vnc-viewer-note-background: var(--secondary-main);
-  --vnc-viewer-note-text-color: var(--common-white);
   --vnc-viewer-info-border-color: var(--neutral-grey-300);
   --vnc-viewer-info-background: var(--neutral-grey-100);
+  --vnc-viewer-info-border-radius: var(--border-radius);
+
+  // variables for vnc-viewer/automated-scan-note
+  --vnc-viewer-automated-scan-note-background: var(--secondary-main);
+  --vnc-viewer-automated-scan-note-text-color: var(--common-white);
+  --vnc-viewer-automated-scan-note-border-radius: var(--border-radius);
 
   // variables for file-list
   --file-list-selected-file-chip-color: var(--text-primary);

--- a/app/utils/webusb-adb-install.ts
+++ b/app/utils/webusb-adb-install.ts
@@ -1,0 +1,175 @@
+import type { Adb } from '@yume-chan/adb';
+
+type AdbSyncWriteFile = Parameters<
+  Awaited<ReturnType<Adb['sync']>>['write']
+>[0]['file'];
+
+const TMP_APK_PATH = '/data/local/tmp/cyod_install.apk';
+
+export type InstallProgress =
+  | { stage: 'downloading'; percent: number }
+  | { stage: 'pushing'; percent: number }
+  | { stage: 'installing' }
+  | { stage: 'done' };
+
+export type InstallOptions = {
+  onProgress?: (progress: InstallProgress) => void;
+};
+
+/**
+ * Download the patched APK from `apkUrl`, push it to the device via ADB sync,
+ * then install it with `pm install -r -t`.
+ */
+export async function installApkViaWebUsb(
+  adb: Adb,
+  apkUrl: string,
+  packageName: string,
+  options: InstallOptions = {}
+): Promise<void> {
+  const { onProgress } = options;
+
+  onProgress?.({ stage: 'downloading', percent: 0 });
+
+  const response = await fetch(apkUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch APK: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const contentLength = parseInt(
+    response.headers.get('content-length') ?? '0',
+    10
+  );
+  const apkBytes = await readWithProgress(
+    response,
+    contentLength,
+    (percent) => {
+      onProgress?.({ stage: 'downloading', percent });
+    }
+  );
+
+  onProgress?.({ stage: 'pushing', percent: 0 });
+
+  const sync = await adb.sync();
+  try {
+    await sync.write({
+      filename: TMP_APK_PATH,
+      file: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(apkBytes);
+          controller.close();
+        },
+      }) as unknown as AdbSyncWriteFile,
+    });
+  } finally {
+    await sync.dispose();
+  }
+
+  onProgress?.({ stage: 'installing' });
+
+  // A different signing cert blocks an in-place update, so remove first.
+  try {
+    await adb.subprocess.noneProtocol.spawnWaitText([
+      'pm',
+      'uninstall',
+      packageName,
+    ]);
+  } catch {
+    // not installed
+  }
+
+  const installOutput = await adb.subprocess.noneProtocol.spawnWaitText([
+    'pm',
+    'install',
+    '-r',
+    '-t',
+    TMP_APK_PATH,
+  ]);
+
+  if (!installOutput.includes('Success')) {
+    throw new Error(`pm install failed: ${installOutput.trim()}`);
+  }
+
+  try {
+    await adb.subprocess.noneProtocol.spawnWaitText(['rm', '-f', TMP_APK_PATH]);
+  } catch {
+    // leftover temp file is harmless
+  }
+
+  onProgress?.({ stage: 'done' });
+}
+
+/** Uninstall a package by name. Does not throw if not installed. */
+export async function uninstallApkViaWebUsb(
+  adb: Adb,
+  packageName: string
+): Promise<void> {
+  try {
+    await adb.subprocess.noneProtocol.spawnWaitText([
+      'pm',
+      'uninstall',
+      packageName,
+    ]);
+  } catch {
+    // not installed
+  }
+}
+
+/** Launch an app by package name via monkey. */
+export async function launchAppViaWebUsb(
+  adb: Adb,
+  packageName: string
+): Promise<void> {
+  await adb.subprocess.noneProtocol.spawnWaitText([
+    'monkey',
+    '-p',
+    packageName,
+    '-c',
+    'android.intent.category.LAUNCHER',
+    '1',
+  ]);
+}
+
+async function readWithProgress(
+  response: Response,
+  totalBytes: number,
+  onPercent: (percent: number) => void
+): Promise<Uint8Array> {
+  if (!response.body) {
+    const buf = await response.arrayBuffer();
+    onPercent(100);
+
+    return new Uint8Array(buf);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    chunks.push(value);
+    received += value.length;
+    if (totalBytes > 0) {
+      onPercent(Math.round((received / totalBytes) * 100));
+    }
+  }
+
+  onPercent(100);
+
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -11,33 +11,106 @@ import {
   getPlatformMajorVersion,
 } from 'irene/utils/dynamic-scan-device';
 
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+const selectors = {
+  device: '[data-test-vncViewer-device]',
+  deviceScreen: '[data-test-vncViewer-deviceScreen]',
+  deviceCamera: '[data-test-vncViewer-deviceCamera]',
+  deviceHome: '[data-test-vncViewer-deviceHome]',
+  devicePart: (part) => `[data-test-vncViewer-device${part}]`,
+  canvasContainer: '[data-test-NovncRfb-canvasContainer]',
+  cyodDownload: '[data-test-vncViewer-cyodDownload]',
+  cyodDownloadLink: '[data-test-vncViewer-cyodDownloadLink]',
+  cyodViewer: '[data-test-vncViewer-cyodViewer]',
+  cyodReady: '[data-test-vncViewer-cyodReady]',
+};
+
+// ─── Template ──────────────────────────────────────────────────────────────────
+const TEMPLATE = hbs`
+  <VncViewer
+    @file={{this.file}}
+    @profileId={{this.activeProfileId}}
+    @dynamicScan={{this.dynamicscan}}
+  />
+`;
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+/**
+ * Builds the profile/file/project graph both modules render against, and mocks
+ * the project fetch the component makes while resolving the device frame. The
+ * handler reads `context.platform` when the request runs, so a test only has to
+ * set it before rendering.
+ */
+function setupModels(context) {
+  const store = context.owner.lookup('service:store');
+
+  const profile = context.server.create('profile');
+
+  const project = context.server.create('project', {
+    active_profile_id: profile.id,
+  });
+
+  const file = context.server.create('file', {
+    project: project.id,
+    profile: profile.id,
+    is_active: true,
+  });
+
+  project.update({ last_file: file });
+
+  context.setProperties({
+    store,
+    project,
+    file: store.push(store.normalize('file', file.toJSON())),
+    activeProfileId: profile.id,
+  });
+
+  context.server.get('/v3/projects/:id', (schema, req) => ({
+    ...schema.projects.find(`${req.params.id}`)?.toJSON(),
+    platform: context.platform,
+  }));
+}
+
+/**
+ * Creates a dynamicscan and pushes it into the store as the ember-data record
+ * the component takes as `@dynamicScan`. Returns the mirage model so tests can
+ * assert against the attributes the factory generated.
+ */
+function createDynamicScan(context, { traits = [], ...attrs }) {
+  const dynamicscan = context.server.create('dynamicscan', ...traits, {
+    file: context.file.id,
+    ended_on: null,
+    ...attrs,
+  });
+
+  context.dynamicscan = context.store.push(
+    context.store.normalize('dynamicscan', dynamicscan.toJSON())
+  );
+
+  return dynamicscan;
+}
+
+/**
+ * A CYOD scan built from one of the dynamicscan factory's CYOD traits. The
+ * project platform is taken from the device the trait attached, so the two
+ * cannot disagree.
+ */
+function createCyodScan(context, trait, status) {
+  const dynamicscan = createDynamicScan(context, { traits: [trait], status });
+
+  context.platform = dynamicscan.device_used.platform;
+
+  return dynamicscan;
+}
+
+// ─── Test suites ───────────────────────────────────────────────────────────────
 module('Integration | Component | vnc-viewer', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en');
   setupMirage(hooks);
 
-  hooks.beforeEach(async function () {
-    const store = this.owner.lookup('service:store');
-
-    const profile = this.server.create('profile', { id: '100' });
-
-    const file = this.server.create('file', {
-      project: '1',
-      profile: profile.id,
-      is_active: true,
-    });
-
-    this.server.create('project', {
-      last_file: file,
-      id: '1',
-      active_profile_id: profile.id,
-    });
-
-    this.setProperties({
-      file: store.push(store.normalize('file', file.toJSON())),
-      activeProfileId: profile.id,
-      store,
-    });
+  hooks.beforeEach(function () {
+    setupModels(this);
   });
 
   test.each(
@@ -53,43 +126,30 @@ module('Integration | Component | vnc-viewer', function (hooks) {
       },
     ],
     async function (assert, { platform, deviceClass }) {
-      const dynamicscan = this.server.create('dynamicscan', {
-        file: this.file.id,
+      this.platform = platform;
+
+      createDynamicScan(this, {
         status: ENUMS.DYNAMIC_SCAN_STATUS.NOT_STARTED,
-        ended_on: null,
       });
 
-      this.dynamicscan = this.store.push(
-        this.store.normalize('dynamicscan', dynamicscan.toJSON())
-      );
-
-      this.server.get('/v3/projects/:id', (schema, req) => {
-        return {
-          ...schema.projects.find(`${req.params.id}`)?.toJSON(),
-          platform,
-        };
-      });
-
-      await render(hbs`
-        <VncViewer @file={{this.file}} @profileId={{this.activeProfileId}} @dynamicScan={{this.dynamicscan}} />
-      `);
+      await render(TEMPLATE);
 
       deviceClass.split(' ').forEach((val) => {
-        assert.dom('[data-test-vncViewer-device]').hasClass(val);
+        assert.dom(selectors.device).hasClass(val);
       });
 
       ['TopBar', 'Sleep', 'Volume'].forEach((it) => {
-        assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
+        assert.dom(selectors.devicePart(it)).doesNotExist();
       });
 
-      assert.dom('[data-test-vncViewer-deviceCamera]').exists();
-      assert.dom('[data-test-vncViewer-deviceScreen]').hasClass('screen');
+      assert.dom(selectors.deviceCamera).exists();
+      assert.dom(selectors.deviceScreen).hasClass('screen');
 
       if (platform === ENUMS.PLATFORM.IOS) {
-        assert.dom('[data-test-vncViewer-deviceHome]').exists();
+        assert.dom(selectors.deviceHome).exists();
 
         ['Speaker', 'BottomBar'].forEach((it) => {
-          assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
+          assert.dom(selectors.devicePart(it)).doesNotExist();
         });
       }
     }
@@ -133,33 +193,20 @@ module('Integration | Component | vnc-viewer', function (hooks) {
       assert,
       { platform, isTablet, deviceClass, platformVersion, status }
     ) {
+      this.platform = platform;
+
       const deviceUsed = this.server.create('device', {
         is_tablet: isTablet,
         platform,
         platform_version: platformVersion,
       });
 
-      const dynamicscan = this.server.create('dynamicscan', {
-        file: this.file.id,
+      createDynamicScan(this, {
         status: status || ENUMS.DYNAMIC_SCAN_STATUS.READY_FOR_INTERACTION,
-        ended_on: null,
         device_used: deviceUsed.toJSON(),
       });
 
-      this.dynamicscan = this.store.push(
-        this.store.normalize('dynamicscan', dynamicscan.toJSON())
-      );
-
-      this.server.get('/v3/projects/:id', (schema, req) => {
-        return {
-          ...schema.projects.find(`${req.params.id}`)?.toJSON(),
-          platform,
-        };
-      });
-
-      await render(hbs`
-        <VncViewer @file={{this.file}} @profileId={{this.activeProfileId}} @dynamicScan={{this.dynamicscan}} />
-      `);
+      await render(TEMPLATE);
 
       const isScanInProgress =
         this.dynamicscan.isBooting ||
@@ -175,46 +222,44 @@ module('Integration | Component | vnc-viewer', function (hooks) {
         platformMajorVersion >= IOS_MODERN_DEVICE_VERSION_CUTOFF;
 
       if (usesModernIOSDeviceFrame) {
-        assert
-          .dom('[data-test-vncViewer-device]')
-          .doesNotHaveClass('marvel-device');
-        assert.dom('[data-test-vncViewer-deviceScreen]').exists();
-        assert.dom('[data-test-vncViewer-deviceCamera]').doesNotExist();
-        assert.dom('[data-test-vncViewer-deviceHome]').doesNotExist();
+        assert.dom(selectors.device).doesNotHaveClass('marvel-device');
+        assert.dom(selectors.deviceScreen).exists();
+        assert.dom(selectors.deviceCamera).doesNotExist();
+        assert.dom(selectors.deviceHome).doesNotExist();
       } else {
         deviceClass.split(' ').forEach((val) => {
-          assert.dom('[data-test-vncViewer-device]').hasClass(val);
+          assert.dom(selectors.device).hasClass(val);
         });
 
-        assert.dom('[data-test-vncViewer-deviceCamera]').exists();
-        assert.dom('[data-test-vncViewer-deviceScreen]').hasClass('screen');
+        assert.dom(selectors.deviceCamera).exists();
+        assert.dom(selectors.deviceScreen).hasClass('screen');
 
         if (platform === ENUMS.PLATFORM.IOS) {
-          assert.dom('[data-test-vncViewer-deviceHome]').exists();
+          assert.dom(selectors.deviceHome).exists();
         }
       }
 
       ['TopBar', 'Sleep', 'Volume'].forEach((it) => {
         if (!usesModernIOSDeviceFrame && isScanInProgress && isTablet) {
-          assert.dom(`[data-test-vncViewer-device${it}]`).exists();
+          assert.dom(selectors.devicePart(it)).exists();
         } else {
-          assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
+          assert.dom(selectors.devicePart(it)).doesNotExist();
         }
       });
 
       if (platform === ENUMS.PLATFORM.IOS && !usesModernIOSDeviceFrame) {
         ['Speaker', 'BottomBar'].forEach((it) => {
           if (isScanInProgress && isTablet) {
-            assert.dom(`[data-test-vncViewer-device${it}]`).exists();
+            assert.dom(selectors.devicePart(it)).exists();
           } else {
-            assert.dom(`[data-test-vncViewer-device${it}]`).doesNotExist();
+            assert.dom(selectors.devicePart(it)).doesNotExist();
           }
         });
       }
 
       if (this.dynamicscan.isReadyOrRunning) {
         assert
-          .dom('[data-test-NovncRfb-canvasContainer]')
+          .dom(selectors.canvasContainer)
           .hasAttribute(
             'data-contain-canvas',
             usesModernIOSDeviceFrame ? 'true' : 'false'
@@ -222,4 +267,79 @@ module('Integration | Component | vnc-viewer', function (hooks) {
       }
     }
   );
+});
+
+module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    setupModels(this);
+
+    window.WebSocket = class {
+      constructor() {}
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    };
+  });
+
+  test('PROXY_CYOD + INSTALLING shows download link', async function (assert) {
+    const scan = createCyodScan(
+      this,
+      'withProxyCyodDevice',
+      ENUMS.DYNAMIC_SCAN_STATUS.INSTALLING
+    );
+
+    await render(TEMPLATE);
+
+    assert.dom(selectors.cyodDownload).exists();
+
+    assert
+      .dom(selectors.cyodDownloadLink)
+      .hasAttribute('href', scan.device_used.android_download_url);
+  });
+
+  test('PROXY_CYOD + READY shows CyodViewer', async function (assert) {
+    createCyodScan(
+      this,
+      'withProxyCyodDevice',
+      ENUMS.DYNAMIC_SCAN_STATUS.READY_FOR_INTERACTION
+    );
+
+    await render(TEMPLATE);
+
+    assert.dom(selectors.cyodViewer).exists();
+    assert.dom(selectors.cyodReady).doesNotExist();
+  });
+
+  test('REMOTE_CYOD + INSTALLING shows iOS install link', async function (assert) {
+    const scan = createCyodScan(
+      this,
+      'withRemoteCyodDevice',
+      ENUMS.DYNAMIC_SCAN_STATUS.INSTALLING
+    );
+
+    await render(TEMPLATE);
+
+    assert.dom(selectors.cyodDownload).exists();
+
+    assert
+      .dom(selectors.cyodDownloadLink)
+      .hasAttribute('href', scan.device_used.ios_itms_url);
+  });
+
+  test('REMOTE_CYOD + READY shows interact on device', async function (assert) {
+    createCyodScan(
+      this,
+      'withRemoteCyodDevice',
+      ENUMS.DYNAMIC_SCAN_STATUS.READY_FOR_INTERACTION
+    );
+
+    await render(TEMPLATE);
+
+    assert.dom(selectors.cyodReady).exists();
+    assert.dom(selectors.cyodViewer).doesNotExist();
+  });
 });


### PR DESCRIPTION
5/7 in the CYOD stack. Bases on #1715 (cyod-04-signing-certificates). Merge in order 01→07.

The scrcpy-backed CYOD viewer, the WebUSB auto-install path, and the vnc-viewer changes that route CYOD scans to them instead of noVNC.

Includes a fix worth flagging: `filePlatform` read the project relationship synchronously and fell back to `0`, which is `ANDROID` — so an unresolved project drew the Android device skin for iOS scans. It now resolves via `resolveFileProject` and treats unknown as `-1`, drawing no skin rather than the wrong one. That was the cause of 5 long-standing vnc-viewer test failures.

cc @Yibaebi