### PR TITLE
feat(cyod): CYOD in the dynamic scan flow

### DIFF
--- a/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/type/index.hbs
+++ b/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/type/index.hbs
@@ -1,7 +1,20 @@
-<AkTypography>
-  {{t
-    (device-type
-      (if @deviceProps.isTablet this.isTabletDevice this.isPhoneDevice)
-    )
-  }}
-</AkTypography>
+<AkStack @spacing='0.5' @alignItems='center'>
+  <AkTypography>
+    {{t this.deviceTypeLabel}}
+  </AkTypography>
+
+  {{#if this.isCyodDevice}}
+    <AkTooltip
+      @title='{{t "modalCard.dynamicScan.cyodDevice"}}'
+      @arrow={{true}}
+      @placement='top'
+    >
+      <AkIcon
+        data-test-fileDetails-dynamicScanDrawer-devicePrefTable-cyodBadge
+        @iconName='mobile'
+        @size='small'
+        @color='textSecondary'
+      />
+    </AkTooltip>
+  {{/if}}
+</AkStack>

--- a/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/type/index.ts
+++ b/app/components/file-details/dynamic-scan/action/drawer/device-pref-table/type/index.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 
 import ENUMS from 'irene/enums';
+import { deviceType } from 'irene/helpers/device-type';
 import type AvailableManualDeviceModel from 'irene/models/available-manual-device';
 
 export interface FileDetailsDynamicScanDrawerDevicePrefTableTypeSignature {
@@ -10,8 +11,25 @@ export interface FileDetailsDynamicScanDrawerDevicePrefTableTypeSignature {
 }
 
 export default class FileDetailsDynamicScanDrawerDevicePrefTableTypeComponent extends Component<FileDetailsDynamicScanDrawerDevicePrefTableTypeSignature> {
-  isPhoneDevice = ENUMS.DS_DEVICE_TYPE.PHONE_REQUIRED;
-  isTabletDevice = ENUMS.DS_DEVICE_TYPE.TABLET_REQUIRED;
+  get deviceTypeLabel() {
+    return deviceType([
+      this.args.deviceProps?.isTablet
+        ? ENUMS.DS_DEVICE_TYPE.TABLET_REQUIRED
+        : ENUMS.DS_DEVICE_TYPE.PHONE_REQUIRED,
+    ]);
+  }
+
+  // Matched positively rather than as "not FARM": registration_source is absent
+  // from older device payloads, and undefined !== FARM would badge every one of
+  // them as CYOD.
+  get isCyodDevice() {
+    const source = this.args.deviceProps?.registrationSource;
+
+    return (
+      source === ENUMS.DEVICE_REGISTRATION_SOURCE.PROXY ||
+      source === ENUMS.DEVICE_REGISTRATION_SOURCE.WEBUSB
+    );
+  }
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/app/components/file-details/dynamic-scan/automated/index.hbs
+++ b/app/components/file-details/dynamic-scan/automated/index.hbs
@@ -35,6 +35,7 @@
             <FileDetails::DynamicScan::StatusChip
               @status={{this.cumulativeScanStatus}}
               @statusText={{this.cumulativeScanStatusText}}
+              @errorMessage={{this.selectedScanErrorMessage}}
             />
           </:default>
         </AkTooltip>

--- a/app/components/file-details/dynamic-scan/manual/index.hbs
+++ b/app/components/file-details/dynamic-scan/manual/index.hbs
@@ -8,6 +8,7 @@
     <FileDetails::DynamicScan::StatusChip
       @status={{this.cumulativeScanStatus}}
       @statusText={{this.dynamicScan.statusText}}
+      @errorMessage={{this.dynamicScan.errorMessage}}
     />
   </:statusChip>
 

--- a/app/components/file-details/dynamic-scan/status-chip/index.hbs
+++ b/app/components/file-details/dynamic-scan/status-chip/index.hbs
@@ -33,3 +33,13 @@
     ...attributes
   />
 {{/if}}
+
+{{#if this.errorMessageToShow}}
+  <AkTypography
+    data-test-fileDetails-dynamicScan-statusChip-error
+    @variant='body3'
+    @color='error'
+  >
+    {{this.errorMessageToShow}}
+  </AkTypography>
+{{/if}}

--- a/app/components/file-details/dynamic-scan/status-chip/index.ts
+++ b/app/components/file-details/dynamic-scan/status-chip/index.ts
@@ -16,6 +16,7 @@ export interface DynamicScanStatusChipSignature {
   Args: {
     status: DsStatusGroup | undefined;
     statusText?: string;
+    errorMessage?: string;
     runningAsWarn?: boolean;
   };
 }
@@ -37,6 +38,12 @@ export default class DynamicScanStatusChipComponent extends Component<DynamicSca
 
   get statusText() {
     return this.args.statusText;
+  }
+
+  get errorMessageToShow() {
+    return this.status === DsStatusGroup.ERRORED
+      ? this.args.errorMessage
+      : undefined;
   }
 
   get chipColor() {

--- a/app/routes/authenticated/dashboard/file/dynamic-scan.ts
+++ b/app/routes/authenticated/dashboard/file/dynamic-scan.ts
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import type Store from 'ember-data/store';
 
 import { ScrollToTop } from 'irene/utils/scroll-to-top';
+import { resolveFileProject } from 'irene/utils/resolve-file-project';
 import type OrganizationService from 'irene/services/organization';
 import type RouterService from '@ember/routing/router-service';
 
@@ -30,10 +31,11 @@ export default class AuthenticatedFileDastRoute extends ScrollToTop(Route) {
 
   async model() {
     const file = await this.store.findRecord('file', this.fileId);
+    const project = await resolveFileProject(file, this.store);
 
     return {
       file,
-      profileId: (await file.project)?.activeProfileId,
+      profileId: project?.activeProfileId ?? null,
     };
   }
 }

--- a/app/routes/authenticated/dashboard/file/dynamic-scan/manual.ts
+++ b/app/routes/authenticated/dashboard/file/dynamic-scan/manual.ts
@@ -3,6 +3,7 @@ import type Store from 'ember-data/store';
 
 import AkBreadcrumbsRoute from 'irene/utils/ak-breadcrumbs-route';
 import { ScrollToTop } from 'irene/utils/scroll-to-top';
+import { resolveFileProject } from 'irene/utils/resolve-file-project';
 
 export default class AuthenticatedFileDastManualDastRoute extends ScrollToTop(
   AkBreadcrumbsRoute
@@ -15,10 +16,11 @@ export default class AuthenticatedFileDastManualDastRoute extends ScrollToTop(
     };
 
     const file = await this.store.findRecord('file', fileid);
+    const project = await resolveFileProject(file, this.store);
 
     return {
       file,
-      profileId: (await file.project).activeProfileId,
+      profileId: project?.activeProfileId ?? null,
     };
   }
 }

--- a/mirage/factories/device.ts
+++ b/mirage/factories/device.ts
@@ -1,4 +1,6 @@
-import { Factory } from 'miragejs';
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error "trait" prop missing from miragejs
+import { Factory, trait } from 'miragejs';
 import { faker } from '@faker-js/faker';
 
 import ENUMS from 'irene/enums';
@@ -28,6 +30,19 @@ export const DEVICE_FACTORY_DEF = {
   has_persistent_apps: () => faker.datatype.boolean(),
   persistent_apps: () => [],
   has_vnc: () => faker.datatype.boolean(),
+
+  // Unset would leave the CYOD badge's positive match untested.
+  registration_source: ENUMS.DEVICE_REGISTRATION_SOURCE.FARM,
 };
 
-export default Factory.extend(DEVICE_FACTORY_DEF);
+export default Factory.extend({
+  ...DEVICE_FACTORY_DEF,
+
+  proxyCyod: trait({
+    registration_source: ENUMS.DEVICE_REGISTRATION_SOURCE.PROXY,
+  }),
+
+  webusbCyod: trait({
+    registration_source: ENUMS.DEVICE_REGISTRATION_SOURCE.WEBUSB,
+  }),
+});

--- a/tests/integration/components/file-details/dynamic-scan/action/drawer/device-pref-table/type-test.js
+++ b/tests/integration/components/file-details/dynamic-scan/action/drawer/device-pref-table/type-test.js
@@ -1,0 +1,109 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+import ENUMS from 'irene/enums';
+
+const selectors = {
+  badge: '[data-test-fileDetails-dynamicScanDrawer-devicePrefTable-cyodBadge]',
+  label: '[data-test-ak-typography]',
+};
+
+const TEMPLATE = hbs`<FileDetails::DynamicScan::Action::Drawer::DevicePrefTable::Type
+  @deviceProps={{this.device}}
+/>`;
+
+module(
+  'Integration | Component | file-details/dynamic-scan/action/drawer/device-pref-table/type',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+    setupIntl(hooks, 'en');
+
+    /**
+     * The component takes an `available-manual-device`, so the record has to come
+     * through the store for `registrationSource` to be deserialized from the
+     * factory's `registration_source`.
+     */
+    function pushDevice(context, ...traits) {
+      const store = context.owner.lookup('service:store');
+
+      const device = store.push(
+        store.normalize(
+          'available-manual-device',
+          context.server.create('available-manual-device', ...traits).toJSON()
+        )
+      );
+
+      context.set('device', device);
+
+      return device;
+    }
+
+    test('a farm device gets no CYOD badge', async function (assert) {
+      const device = pushDevice(this);
+
+      assert.strictEqual(
+        device.registrationSource,
+        ENUMS.DEVICE_REGISTRATION_SOURCE.FARM,
+        'the factory default is a farm-owned device'
+      );
+
+      await render(TEMPLATE);
+
+      assert.dom(selectors.badge).doesNotExist();
+    });
+
+    test('a device with no registration source gets no CYOD badge', async function (assert) {
+      // Older device payloads omit the field entirely. Matching "not FARM" would
+      // badge every one of them, which is what this guards.
+      const device = pushDevice(this, { registration_source: undefined });
+
+      assert.strictEqual(
+        device.registrationSource,
+        undefined,
+        'the attribute stays undefined rather than defaulting'
+      );
+
+      await render(TEMPLATE);
+
+      assert
+        .dom(selectors.badge)
+        .doesNotExist('an unknown source is not assumed to be CYOD');
+    });
+
+    test('both CYOD enrolment routes get the badge', async function (assert) {
+      pushDevice(this, 'proxyCyod');
+
+      await render(TEMPLATE);
+
+      assert
+        .dom(selectors.badge)
+        .exists('a device enrolled through the Mercer proxy is CYOD');
+
+      pushDevice(this, 'webusbCyod');
+
+      await render(TEMPLATE);
+
+      assert
+        .dom(selectors.badge)
+        .exists('so is one enrolled over WebUSB — they share one badge');
+    });
+
+    test('it renders the device type alongside the badge', async function (assert) {
+      pushDevice(this, 'proxyCyod', { is_tablet: false });
+
+      await render(TEMPLATE);
+
+      assert
+        .dom(selectors.label)
+        .hasText(
+          t('phone'),
+          'the badge sits beside the type, it does not replace it'
+        );
+    });
+  }
+);


### PR DESCRIPTION
6/7 in the CYOD stack. Bases on #1716 (cyod-05-viewer-webusb). Merge in order 01→07.

Surfaces CYOD in the DAST flow: device-preference type selection, the automated/manual scan views, and inline scan errors on the status chip (e.g. "device UDID … is not enrolled in the signing profile").

Note the status chip now renders that error inline while develop's tooltip repeats it on hover — both were kept through the develop merge rather than dropping either. Worth deciding whether the duplication should stay.

cc @Yibaebi