### PR TITLE
ADD: fake app ignore message changes

### DIFF
--- a/app/components/storeknox/fake-apps/ignored-banner/index.hbs
+++ b/app/components/storeknox/fake-apps/ignored-banner/index.hbs
@@ -61,7 +61,7 @@
             local-class='fake-apps-ignored-banner-text'
             data-test-storeknoxFakeAppsIgnoredBanner-text
           >
-            {{t 'storeknox.fakeApps.ignoredBannerAddedToInventory'}}
+            {{t 'storeknox.fakeApps.ignoredBannerIgnored'}}
             <strong>{{this.ignoredOnString}}</strong>
           </AkTypography>
         {{/if}}

--- a/tests/acceptance/storeknox/fake-apps/ignored-banner-test.js
+++ b/tests/acceptance/storeknox/fake-apps/ignored-banner-test.js
@@ -108,7 +108,7 @@ module('Acceptance | storeknox/fake-apps/ignored-banner', function (hooks) {
 
     assert
       .dom(bannerText)
-      .containsText(t('storeknox.fakeApps.ignoredBannerAddedToInventory'))
+      .containsText(t('storeknox.fakeApps.ignoredBannerIgnored'))
       .containsText(dayjs(reviewedOn).format('MMM DD, YYYY'));
 
     assert

--- a/translations/en.json
+++ b/translations/en.json
@@ -2661,7 +2661,7 @@
       "suspectedApps": "Suspected Apps",
       "originalAppDetails": "Original App Details",
       "ignoredBannerIgnoredAndAddedToInventory": "Note - This app has been Ignored & Add to Inventory on",
-      "ignoredBannerAddedToInventory": "Note - This app was added to Inventory on",
+      "ignoredBannerIgnored": "Note - This app has been Ignored on",
       "findings": "Findings",
       "overallScore": "Overall Score",
       "overallScoreInfo": "Similarity score based on semantic, package, logo, and developer analysis",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -2661,7 +2661,7 @@
       "suspectedApps": "Suspected Apps",
       "originalAppDetails": "Original App Details",
       "ignoredBannerIgnoredAndAddedToInventory": "Note - This app has been Ignored & Add to Inventory on",
-      "ignoredBannerAddedToInventory": "Note - This app was added to Inventory on",
+      "ignoredBannerIgnored": "Note - This app has been Ignored on",
       "findings": "Findings",
       "overallScore": "Overall Score",
       "overallScoreInfo": "Similarity score based on semantic, package, logo, and developer analysis",


### PR DESCRIPTION
## Summary of Changes

### 1. Translation Key & String Update
- **[translations/en.json](file:///Users/siddharth/Desktop/Appknox/projects/irene/translations/en.json#L2664)**: Renamed key `ignoredBannerAddedToInventory` → `ignoredBannerIgnored` and updated value to `"Note - This app has been Ignored on"`.
- **[translations/ja.json](file:///Users/siddharth/Desktop/Appknox/projects/irene/translations/ja.json#L2664)**: Renamed key `ignoredBannerAddedToInventory` → `ignoredBannerIgnored` and updated value to `"Note - This app has been Ignored on"`.

### 2. Component Template
- **[app/components/storeknox/fake-apps/ignored-banner/index.hbs](file:///Users/siddharth/Desktop/Appknox/projects/irene/app/components/storeknox/fake-apps/ignored-banner/index.hbs#L64)**: Updated translation helper invocation to `{{t 'storeknox.fakeApps.ignoredBannerIgnored'}}`.

### 3. Acceptance Tests
- **[tests/acceptance/storeknox/fake-apps/ignored-banner-test.js](file:///Users/siddharth/Desktop/Appknox/projects/irene/tests/acceptance/storeknox/fake-apps/ignored-banner-test.js#L111)**: Updated banner text assertion to reference `t('storeknox.fakeApps.ignoredBannerIgnored')`.
