### PR TITLE
remove deprecated KnoxIQ CI/CD auto-execute toggle from AI features settings

### DIFF
--- a/app/components/organization/ai-powered-features/index.ts
+++ b/app/components/organization/ai-powered-features/index.ts
@@ -10,7 +10,7 @@ import parseError from 'irene/utils/parse-error';
 import type OrganizationService from 'irene/services/organization';
 import type OrganizationAiFeatureModel from 'irene/models/organization-ai-feature';
 
-type AiFeatureKey = 'pii' | 'reporting' | 'autoExecuteKnoxiqOnCicdUpload';
+type AiFeatureKey = 'pii' | 'reporting';
 
 type AiFeatureDrawerInfo = {
   title: string;
@@ -81,20 +81,6 @@ export default class OrganizationAiPoweredFeaturesComponent extends Component {
         isToggling:
           this.featureToToggle === 'pii' && this.toggleFeature.isRunning,
       },
-      !this.organization.hideUpsellUIStatus.aiKnoxiq && {
-        featureKey: 'autoExecuteKnoxiqOnCicdUpload' as const,
-        isChecked: Boolean(this.aiFeatures?.autoExecuteKnoxiqOnCicdUpload),
-        enabled: this.features?.knoxiq,
-        label: this.intl.t('knoxIq.title'),
-        description: this.intl.t('knoxIq.orgSettingsDesc'),
-        header: this.intl.t('knoxIq.title'),
-        drawerInfo: null,
-        clickable: false,
-
-        isToggling:
-          this.featureToToggle === 'autoExecuteKnoxiqOnCicdUpload' &&
-          this.toggleFeature.isRunning,
-      },
     ].filter(Boolean) as Array<AiFeature>;
   }
 
@@ -128,8 +114,6 @@ export default class OrganizationAiPoweredFeaturesComponent extends Component {
         return this.piiDrawerInfo;
       case 'reporting':
         return this.reportDrawerInfo;
-      case 'autoExecuteKnoxiqOnCicdUpload':
-        return [];
       default:
         return null;
     }

--- a/app/models/organization-ai-feature.ts
+++ b/app/models/organization-ai-feature.ts
@@ -6,9 +6,6 @@ export default class OrganizationAiFeatureModel extends Model {
 
   @attr('boolean')
   declare pii: boolean;
-
-  @attr('boolean')
-  declare autoExecuteKnoxiqOnCicdUpload: boolean;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/services/organization.ts
+++ b/app/services/organization.ts
@@ -42,7 +42,6 @@ export default class OrganizationService extends Service {
         !this.orgFeatures?.store_release_readiness && this.hideUpsellUI,
       aiReporting: !this.orgAiFeatures?.reporting && this.hideUpsellUI,
       aiPii: !this.orgAiFeatures?.pii && this.hideUpsellUI,
-      aiKnoxiq: !this.orgAiFeatures?.knoxiq && this.hideUpsellUI,
 
       dynamicScanAutomation:
         !this.orgFeatures?.dynamicscan_automation && this.hideUpsellUI,

--- a/translations/en.json
+++ b/translations/en.json
@@ -995,7 +995,6 @@
     "knoxIQPreferenceDesc": "Choose your preference how KnoxIQ should work for this project?",
     "nameOfVulnerability": "Name of Vulnerability",
     "needsReview": "Needs Review",
-    "orgSettingsDesc": "Enable automatic execution of KnoxIQ for all CI/CD uploads",
     "originalAnalysis": "Original Analysis",
     "reasoning": "reasoning",
     "remediation": "Remediation",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -995,7 +995,6 @@
     "knoxIQPreferenceDesc": "Choose your preference how KnoxIQ should work for this project?",
     "nameOfVulnerability": "Name of Vulnerability",
     "needsReview": "Needs Review",
-    "orgSettingsDesc": "Enable automatic execution of KnoxIQ for all CI/CD uploads",
     "originalAnalysis": "Original Analysis",
     "reasoning": "reasoning",
     "remediation": "Remediation",


### PR DESCRIPTION
Removes the deprecated KnoxIQ auto-execute toggle from **Organization → AI-powered features**.

### Why

CI/CD KnoxIQ runs are now requested per build with `appknox upload --knoxiq` (mycroft PD-2352). The backend no longer reads or accepts `auto_execute_knoxiq_on_cicd_upload`, so the switch controls nothing. There is no replacement setting — the choice moved to the pipeline.

### Changes

- `organization/ai-powered-features` — drop the KnoxIQ row, its `AiFeatureKey` union member and its `drawerInfo` case
- `organization-ai-feature` model — drop the `autoExecuteKnoxiqOnCicdUpload` attribute
- `organization` service — drop the now-unused `aiKnoxiq` upsell flag
- `en.json` / `ja.json` — drop `knoxIq.orgSettingsDesc`

### Release ordering

Should merge before or with mycroft [#2286](https://github.com/appknox/mycroft/pull/2286). If mycroft ships first, the toggle renders permanently off and flipping it shows "Status updated successfully" while nothing persists.
