### PR TITLE
feat(cyod): disable the manual install prompt and fix the viewer's stream lifecycle

### DIFF
--- a/app/components/cyod-viewer/index.hbs
+++ b/app/components/cyod-viewer/index.hbs
@@ -1,7 +1,11 @@
 <div data-test-cyodViewer local-class='cyod-viewer-root' ...attributes>
+  {{! The canvas stays mounted in every state. Swapping it out tears down the
+      modifier, which closes a socket that may still be connecting -- and then
+      nothing is left to reconnect with. Status is drawn over it instead. }}
   {{#if this.errorMessage}}
     <AkStack
       data-test-cyodViewer-error
+      local-class='cyod-overlay'
       @direction='column'
       @alignItems='center'
       @spacing='1'
@@ -9,34 +13,42 @@
       <AkIcon @iconName='warning' @color='warn' />
 
       <AkTypography @color='textSecondary'>{{this.errorMessage}}</AkTypography>
-    </AkStack>
-  {{else}}
-    {{#unless this.isConnected}}
-      <AkStack
-        data-test-cyodViewer-connecting
-        @direction='column'
-        @alignItems='center'
-        @spacing='1'
+
+      <AkButton
+        data-test-cyodViewer-retryBtn
+        @variant='outlined'
+        @size='small'
+        {{on 'click' this.retry}}
       >
-        <AkLoader @size={{24}} />
+        {{t 'cyod.viewer.retry'}}
+      </AkButton>
+    </AkStack>
+  {{else if (not this.isConnected)}}
+    <AkStack
+      data-test-cyodViewer-connecting
+      local-class='cyod-overlay'
+      @direction='column'
+      @alignItems='center'
+      @spacing='1'
+    >
+      <AkLoader @size={{24}} />
 
-        <AkTypography @color='textSecondary'>
-          {{t 'cyod.detectingDevice'}}
-        </AkTypography>
-      </AkStack>
-    {{/unless}}
-
-    {{! Remote input, not a click target: a drag needs down/move/up as they happen. }}
-    {{! template-lint-disable no-pointer-down-event-binding }}
-    <canvas
-      data-test-cyodViewer-canvas
-      local-class='cyod-canvas {{unless this.isConnected "hidden"}}'
-      {{this.setupCanvas}}
-      {{on 'pointerdown' this.handlePointerDown}}
-      {{on 'pointermove' this.handlePointerMove}}
-      {{on 'pointerup' this.handlePointerUp}}
-      {{on 'pointercancel' this.handlePointerCancel}}
-      {{on 'pointerleave' this.handlePointerCancel}}
-    />
+      <AkTypography @color='textSecondary'>
+        {{t 'cyod.detectingDevice'}}
+      </AkTypography>
+    </AkStack>
   {{/if}}
+
+  {{! Remote input, not a click target: a drag needs down/move/up as they happen. }}
+  {{! template-lint-disable no-pointer-down-event-binding }}
+  <canvas
+    data-test-cyodViewer-canvas
+    local-class='cyod-canvas {{unless this.isConnected "hidden"}}'
+    {{this.setupCanvas}}
+    {{on 'pointerdown' this.handlePointerDown}}
+    {{on 'pointermove' this.handlePointerMove}}
+    {{on 'pointerup' this.handlePointerUp}}
+    {{on 'pointercancel' this.handlePointerCancel}}
+    {{on 'pointerleave' this.handlePointerCancel}}
+  />
 </div>

--- a/app/components/cyod-viewer/index.hbs
+++ b/app/components/cyod-viewer/index.hbs
@@ -1,4 +1,4 @@
-<div data-test-cyodViewer local-class='cyod-viewer-root' ...attributes>
+<div data-test-cyodViewer-root local-class='cyod-viewer-root' ...attributes>
   {{! The canvas stays mounted in every state. Swapping it out tears down the
       modifier, which closes a socket that may still be connecting -- and then
       nothing is left to reconnect with. Status is drawn over it instead. }}
@@ -17,7 +17,6 @@
       <AkButton
         data-test-cyodViewer-retryBtn
         @variant='outlined'
-        @size='small'
         {{on 'click' this.retry}}
       >
         {{t 'cyod.viewer.retry'}}

--- a/app/components/cyod-viewer/index.scss
+++ b/app/components/cyod-viewer/index.scss
@@ -18,3 +18,12 @@
     display: none;
   }
 }
+
+// Status is drawn over the canvas rather than replacing it, so tearing the
+// canvas out never kills a live (or connecting) stream socket.
+.cyod-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/app/components/cyod-viewer/index.scss
+++ b/app/components/cyod-viewer/index.scss
@@ -25,5 +25,4 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  pointer-events: auto;
 }

--- a/app/components/cyod-viewer/index.ts
+++ b/app/components/cyod-viewer/index.ts
@@ -98,6 +98,13 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
     this.sendTouch('up', event);
   }
 
+  @action
+  retry() {
+    this.reconnectAttempt = 0;
+    this.errorMessage = null;
+    this.connect();
+  }
+
   private sendTouch(action: string, event: PointerEvent) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.canvas) {
       return;
@@ -107,13 +114,6 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
     const x = (event.clientX - rect.left) / rect.width;
     const y = (event.clientY - rect.top) / rect.height;
     this.ws.send(JSON.stringify({ type: 'touch', action, x, y }));
-  }
-
-  @action
-  retry() {
-    this.reconnectAttempt = 0;
-    this.errorMessage = null;
-    this.connect();
   }
 
   private connect() {

--- a/app/components/cyod-viewer/index.ts
+++ b/app/components/cyod-viewer/index.ts
@@ -10,6 +10,10 @@ import type LoggerService from 'irene/services/logger';
 
 const SCRCPY_WS_PATH = '/devicefarm/ws/scrcpy/';
 
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 8000;
+
 export interface CyodViewerSignature {
   Args: {
     scanToken: string;
@@ -28,6 +32,8 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
   @tracked errorMessage: string | null = null;
 
   private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
   private canvas: HTMLCanvasElement | null = null;
   private ctx: CanvasRenderingContext2D | null = null;
   private videoDecoder: VideoDecoder | null = null;
@@ -103,6 +109,13 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
     this.ws.send(JSON.stringify({ type: 'touch', action, x, y }));
   }
 
+  @action
+  retry() {
+    this.reconnectAttempt = 0;
+    this.errorMessage = null;
+    this.connect();
+  }
+
   private connect() {
     if (this.ws) {
       return;
@@ -113,44 +126,113 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
 
     this.errorMessage = null;
 
-    this.ws = new WebSocket(this.wsUrl);
-    this.ws.binaryType = 'arraybuffer';
+    let ws: WebSocket;
 
-    this.ws.onopen = () => {
-      if (this.isDestroyed || this.isDestroying) {
+    // A bad devicefarm URL throws here, on the modifier's install path, which
+    // would take the whole render down with it.
+    try {
+      ws = new WebSocket(this.wsUrl);
+    } catch (err) {
+      this.logger.error('[CyodViewer] could not open the stream socket:', err);
+      this.errorMessage = this.intl.t('cyod.viewer.connectionFailed');
+
+      return;
+    }
+
+    ws.binaryType = 'arraybuffer';
+    this.ws = ws;
+
+    // A socket abandoned mid-handshake keeps firing its handlers. Every one of
+    // them must confirm it is still the live socket first, or a superseded
+    // connection reports its own failure over the replacement that took its
+    // place -- which is what left the viewer stuck until a page refresh.
+    const isCurrent = () =>
+      this.ws === ws && !this.isDestroyed && !this.isDestroying;
+
+    ws.onopen = () => {
+      if (!isCurrent()) {
         return;
       }
+      this.reconnectAttempt = 0;
       this.isConnected = true;
       this.initH264Decoder();
     };
 
-    this.ws.onclose = () => {
-      if (this.isDestroyed || this.isDestroying) {
+    ws.onclose = () => {
+      if (!isCurrent()) {
         return;
       }
       this.isConnected = false;
       this.cleanupDecoder();
+      this.ws = null;
+      this.scheduleReconnect();
     };
 
-    this.ws.onerror = () => {
-      if (this.isDestroyed || this.isDestroying) {
+    // onerror is always followed by onclose, which drives the retry; recording
+    // the failure here as well would surface an error the retry may clear.
+    ws.onerror = () => {
+      if (!isCurrent()) {
         return;
       }
-      this.errorMessage = this.intl.t('cyod.viewer.connectionFailed');
       this.isConnected = false;
     };
 
-    this.ws.onmessage = (event: MessageEvent) => {
+    ws.onmessage = (event: MessageEvent) => {
+      if (!isCurrent()) {
+        return;
+      }
       if (event.data instanceof ArrayBuffer) {
         this.decodeH264Frame(new Uint8Array(event.data));
       }
     };
   }
 
+  private scheduleReconnect() {
+    if (this.reconnectTimer || this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
+    if (this.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+      this.errorMessage = this.intl.t('cyod.viewer.connectionFailed');
+
+      return;
+    }
+
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempt,
+      RECONNECT_MAX_DELAY_MS
+    );
+
+    this.reconnectAttempt++;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+
+      this.connect();
+    }, delay);
+  }
+
   private disconnect() {
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    const ws = this.ws;
+    this.ws = null;
+
+    if (ws) {
+      // Detach before closing: closing a still-connecting socket fires onclose,
+      // which would otherwise queue a reconnect for a canvas being torn down.
+      ws.onopen = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      ws.close();
     }
 
     this.cleanupDecoder();

--- a/app/components/cyod-viewer/index.ts
+++ b/app/components/cyod-viewer/index.ts
@@ -142,10 +142,8 @@ export default class CyodViewerComponent extends Component<CyodViewerSignature> 
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
 
-    // A socket abandoned mid-handshake keeps firing its handlers. Every one of
-    // them must confirm it is still the live socket first, or a superseded
-    // connection reports its own failure over the replacement that took its
-    // place -- which is what left the viewer stuck until a page refresh.
+    // A superseded socket keeps firing; without this it reports its own failure
+    // over the replacement, leaving the viewer stuck until a page refresh.
     const isCurrent = () =>
       this.ws === ws && !this.isDestroyed && !this.isDestroying;
 

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -77,7 +77,11 @@
       {{/if}}
 
       <div data-test-vncViewer-deviceScreen class='screen'>
-        {{#if (and this.isCyodScan @dynamicScan.isInstalling)}}
+        {{#if
+          (and
+            this.manualInstallEnabled this.isCyodScan @dynamicScan.isInstalling
+          )
+        }}
           {{#if this.isWebusbCyod}}
             <AkStack
               data-test-vncViewer-webusbInstall

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -152,13 +152,34 @@
               />
             </AkStack>
           {{/if}}
-        {{else if this.isScrcpyScan}}
+        {{! The stream source exists only between the transition to
+            READY_FOR_INTERACTION, which starts it, and the stop request, which
+            tears it down (moriarty start_proxy_screen_stream /
+            stop_screen_stream). Mounted outside that window the viewer opens a
+            socket with nothing on the far end and can only report a connection
+            failure -- which is what was shown while a scan was still starting
+            and again once it had been cancelled. }}
+        {{else if (and this.isScrcpyScan @dynamicScan.isReadyOrRunning)}}
           <CyodViewer
             data-test-vncViewer-cyodViewer
             @scanToken={{this.scrcpyScanToken}}
             @platform={{this.filePlatform}}
             @authToken={{this.cyodAuthToken}}
           />
+        {{else if (and this.isScrcpyScan @dynamicScan.isStarting)}}
+          <AkStack
+            data-test-vncViewer-cyodPreparing
+            local-class='cyod-ready-note'
+            @direction='column'
+            @alignItems='center'
+            @spacing='1'
+          >
+            <AkLoader @size={{24}} />
+
+            <AkTypography @color='inherit' @variant='subtitle2'>
+              {{t 'cyod.viewer.preparing'}}
+            </AkTypography>
+          </AkStack>
         {{else if (and this.isCyodScan @dynamicScan.isReady)}}
           <AkStack
             data-test-vncViewer-cyodReady

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -77,17 +77,7 @@
       {{/if}}
 
       <div data-test-vncViewer-deviceScreen class='screen'>
-        {{! A scrcpy scan is auto-installed on the proxy device, so it never wants
-            the manual install prompt -- and it must not be swapped for one, since
-            that destroys the viewer and its stream socket mid-connection. }}
-        {{#if
-          (and
-            this.manualInstallEnabled
-            this.isCyodScan
-            @dynamicScan.isInstalling
-            (not this.isScrcpyScan)
-          )
-        }}
+        {{#if this.needsManualInstall}}
           {{#if this.isWebusbCyod}}
             <AkStack
               data-test-vncViewer-webusbInstall
@@ -152,29 +142,21 @@
               />
             </AkStack>
           {{/if}}
-        {{! The stream source exists only between the transition to
-            READY_FOR_INTERACTION, which starts it, and the stop request, which
-            tears it down (moriarty start_proxy_screen_stream /
-            stop_screen_stream). Mounted outside that window the viewer opens a
-            socket with nothing on the far end and can only report a connection
-            failure -- which is what was shown while a scan was still starting
-            and again once it had been cancelled. }}
-        {{else if (and this.isScrcpyScan @dynamicScan.isReadyOrRunning)}}
+        {{else if this.showsScrcpyStream}}
           <CyodViewer
             data-test-vncViewer-cyodViewer
             @scanToken={{this.scrcpyScanToken}}
             @platform={{this.filePlatform}}
             @authToken={{this.cyodAuthToken}}
           />
-        {{else if (and this.isScrcpyScan @dynamicScan.isStarting)}}
+        {{else if this.isPreparingScrcpyStream}}
           <AkStack
             data-test-vncViewer-cyodPreparing
-            local-class='cyod-ready-note'
             @direction='column'
             @alignItems='center'
             @spacing='1'
           >
-            <AkLoader @size={{24}} />
+            <AkLoader data-test-vncViewer-cyodPreparingLoader @size={{24}} />
 
             <AkTypography @color='inherit' @variant='subtitle2'>
               {{t 'cyod.viewer.preparing'}}

--- a/app/components/vnc-viewer/index.hbs
+++ b/app/components/vnc-viewer/index.hbs
@@ -77,9 +77,15 @@
       {{/if}}
 
       <div data-test-vncViewer-deviceScreen class='screen'>
+        {{! A scrcpy scan is auto-installed on the proxy device, so it never wants
+            the manual install prompt -- and it must not be swapped for one, since
+            that destroys the viewer and its stream socket mid-connection. }}
         {{#if
           (and
-            this.manualInstallEnabled this.isCyodScan @dynamicScan.isInstalling
+            this.manualInstallEnabled
+            this.isCyodScan
+            @dynamicScan.isInstalling
+            (not this.isScrcpyScan)
           )
         }}
           {{#if this.isWebusbCyod}}

--- a/app/components/vnc-viewer/index.ts
+++ b/app/components/vnc-viewer/index.ts
@@ -203,6 +203,29 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
     return deviceUsed?.vnc_mode === ENUMS.DEVICE_VNC_MODE.SCRCPY;
   }
 
+  get needsManualInstall() {
+    // Two independent reasons to withhold the prompt: it is disabled outright,
+    // and a scrcpy scan is auto-installed on the proxy device anyway -- swapping
+    // the viewer out for it destroys the stream socket mid-connection.
+    return (
+      this.manualInstallEnabled &&
+      this.isCyodScan &&
+      this.args.dynamicScan?.get('isInstalling') &&
+      !this.isScrcpyScan
+    );
+  }
+
+  get showsScrcpyStream() {
+    // moriarty starts the Mercer relay on the transition to
+    // READY_FOR_INTERACTION and tears it down on the stop request, so outside
+    // that window the viewer dials a source that does not exist.
+    return this.isScrcpyScan && this.args.dynamicScan?.get('isReadyOrRunning');
+  }
+
+  get isPreparingScrcpyStream() {
+    return this.isScrcpyScan && this.args.dynamicScan?.get('isStarting');
+  }
+
   get scrcpyScanToken() {
     return this.args.dynamicScan?.get('moriartyDynamicscanToken') ?? null;
   }

--- a/app/components/vnc-viewer/index.ts
+++ b/app/components/vnc-viewer/index.ts
@@ -18,6 +18,17 @@ import type DynamicscanModel from 'irene/models/dynamicscan';
 import type DevicefarmService from 'irene/services/devicefarm';
 import type CyodAdbSessionService from 'irene/services/cyod-adb-session';
 
+/**
+ * Whether a CYOD scan may ask the user to install the app themselves -- the
+ * WebUSB auto-install prompt, the APK download link and the iOS itms-services
+ * link.
+ *
+ * Disabled: CYOD installs the app on the device server-side, so the manual path
+ * no longer applies. The prompt and everything behind it are left in place; flip
+ * this to true to bring them back.
+ */
+const MANUAL_INSTALL_ENABLED = false;
+
 export interface VncViewerSignature {
   Args: {
     file: FileModel;
@@ -40,6 +51,8 @@ export default class VncViewerComponent extends Component<VncViewerSignature> {
   @tracked webusbInstallStage: string | null = null;
   @tracked webusbInstallPercent = 0;
   @tracked resolvedProject: ProjectModel | null = null;
+
+  manualInstallEnabled = MANUAL_INSTALL_ENABLED;
 
   constructor(owner: unknown, args: VncViewerSignature['Args']) {
     super(owner, args);

--- a/tests/integration/components/cyod-viewer-test.js
+++ b/tests/integration/components/cyod-viewer-test.js
@@ -1,0 +1,272 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import {
+  render,
+  settled,
+  waitUntil,
+  clearRender,
+  click,
+} from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl, t } from 'ember-intl/test-support';
+import Service from '@ember/service';
+
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+const selectors = {
+  canvas: '[data-test-cyodViewer-canvas]',
+  connecting: '[data-test-cyodViewer-connecting]',
+  error: '[data-test-cyodViewer-error]',
+  retryBtn: '[data-test-cyodViewer-retryBtn]',
+};
+
+/**
+ * Minimal WebSocket stand-in. It never completes a handshake on its own, so a
+ * test drives the state transitions explicitly -- which is the point here: the
+ * bug lives entirely in the window between construction and `onopen`.
+ */
+class FakeWebSocket {
+  static instances = [];
+
+  static reset() {
+    FakeWebSocket.instances = [];
+  }
+
+  static get last() {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  }
+
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  onopen = null;
+  onclose = null;
+  onerror = null;
+  onmessage = null;
+  binaryType = 'blob';
+  closeCallCount = 0;
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send() {}
+
+  close() {
+    this.closeCallCount++;
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  // ─── Test drivers ───────────────────────────────────────────────────────────
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  /** What the browser does to a socket that is closed while still CONNECTING. */
+  abort() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onerror?.(new Event('error'));
+    this.onclose?.(new CloseEvent('close', { code: 1006 }));
+  }
+}
+
+const TEMPLATE = hbs`
+  <CyodViewer
+    @scanToken={{this.scanToken}}
+    @platform={{this.platform}}
+    @authToken={{this.authToken}}
+  />
+`;
+
+module('Integration | Component | cyod-viewer', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en');
+
+  hooks.beforeEach(function () {
+    FakeWebSocket.reset();
+
+    this.originalWebSocket = window.WebSocket;
+    window.WebSocket = FakeWebSocket;
+
+    class DevicefarmStub extends Service {
+      urlbase = 'http://devicefarm.test/';
+    }
+
+    class LoggerStub extends Service {
+      error() {}
+      warn() {}
+      info() {}
+    }
+
+    this.owner.register('service:devicefarm', DevicefarmStub);
+    this.owner.register('service:logger', LoggerStub);
+
+    this.setProperties({
+      scanToken: 'SCAN123',
+      platform: 1,
+      authToken: 'auth-token',
+    });
+  });
+
+  hooks.afterEach(function () {
+    window.WebSocket = this.originalWebSocket;
+  });
+
+  test('it opens a stream socket for the scan token', async function (assert) {
+    await render(TEMPLATE);
+
+    assert.dom(selectors.canvas).exists();
+    assert.dom(selectors.connecting).exists();
+    assert.strictEqual(FakeWebSocket.instances.length, 1);
+    assert.strictEqual(
+      FakeWebSocket.last.url,
+      'ws://devicefarm.test/devicefarm/ws/scrcpy/SCAN123/?token=auth-token'
+    );
+  });
+
+  test('the canvas stays mounted in every state', async function (assert) {
+    await render(TEMPLATE);
+
+    // Swapping the canvas out tears down the modifier, which closes a socket
+    // that may still be connecting -- and leaves nothing to reconnect with.
+    assert.dom(selectors.canvas).exists('present while connecting');
+
+    FakeWebSocket.last.open();
+    await settled();
+
+    assert.dom(selectors.canvas).exists('present once connected');
+    assert.dom(selectors.connecting).doesNotExist();
+  });
+
+  test('handlers are detached before a torn-down socket is closed', async function (assert) {
+    await render(TEMPLATE);
+
+    const ws = FakeWebSocket.last;
+    ws.open();
+    await settled();
+
+    await clearRender();
+
+    assert.strictEqual(ws.closeCallCount, 1, 'the socket was closed');
+    assert.strictEqual(ws.onopen, null);
+    assert.strictEqual(ws.onclose, null);
+    assert.strictEqual(ws.onerror, null);
+    assert.strictEqual(ws.onmessage, null);
+  });
+
+  test('a superseded socket cannot report failure over its replacement', async function (assert) {
+    await render(TEMPLATE);
+
+    const first = FakeWebSocket.last;
+
+    first.abort();
+
+    const second = await waitUntil(
+      () => (FakeWebSocket.instances.length === 2 ? FakeWebSocket.last : false),
+      { timeout: 4000 }
+    );
+
+    assert.notStrictEqual(second, first, 'a replacement socket was opened');
+
+    // The abandoned socket fires again after being superseded. Acting on it
+    // would surface an error over a connection that is perfectly healthy.
+    first.onclose?.(new CloseEvent('close', { code: 1006 }));
+    first.onerror?.(new Event('error'));
+    await settled();
+
+    assert.dom(selectors.error).doesNotExist();
+
+    second.open();
+    await settled();
+
+    assert.dom(selectors.connecting).doesNotExist();
+    assert.dom(selectors.error).doesNotExist();
+  });
+
+  test('it reconnects after an unexpected close', async function (assert) {
+    await render(TEMPLATE);
+
+    const first = FakeWebSocket.last;
+    first.open();
+    await settled();
+
+    assert.dom(selectors.connecting).doesNotExist();
+
+    first.readyState = FakeWebSocket.CLOSED;
+    first.onclose?.(new CloseEvent('close', { code: 1006 }));
+    await settled();
+
+    assert
+      .dom(selectors.connecting)
+      .exists('falls back to the connecting state');
+    assert.dom(selectors.error).doesNotExist('a drop is not a hard failure');
+
+    await waitUntil(() => FakeWebSocket.instances.length === 2, {
+      timeout: 4000,
+    });
+
+    FakeWebSocket.last.open();
+    await settled();
+
+    assert.dom(selectors.connecting).doesNotExist();
+    assert.dom(selectors.error).doesNotExist();
+  });
+
+  test('no socket is opened without a scan token', async function (assert) {
+    this.set('scanToken', null);
+
+    await render(TEMPLATE);
+
+    assert.strictEqual(FakeWebSocket.instances.length, 0);
+    assert.dom(selectors.canvas).exists();
+  });
+
+  test('the retry control is absent while the stream is healthy', async function (assert) {
+    await render(TEMPLATE);
+
+    assert.dom(selectors.retryBtn).doesNotExist();
+
+    FakeWebSocket.last.open();
+    await settled();
+
+    assert.dom(selectors.retryBtn).doesNotExist();
+  });
+
+  test('a socket that cannot be constructed surfaces a retry instead of breaking the render', async function (assert) {
+    let shouldThrow = true;
+
+    window.WebSocket = class extends FakeWebSocket {
+      constructor(url) {
+        if (shouldThrow) {
+          throw new SyntaxError('bad url');
+        }
+
+        super(url);
+      }
+    };
+
+    await render(TEMPLATE);
+
+    assert.dom(selectors.error).exists('the failure is reported');
+    assert
+      .dom(selectors.error)
+      .hasTextContaining(t('cyod.viewer.connectionFailed'));
+    assert.dom(selectors.canvas).exists('the canvas survives the error state');
+    assert.dom(selectors.retryBtn).exists();
+
+    shouldThrow = false;
+
+    await click(selectors.retryBtn);
+
+    assert.dom(selectors.error).doesNotExist('retry clears the failure');
+    assert.strictEqual(
+      FakeWebSocket.instances.length,
+      1,
+      'retry opens a fresh socket'
+    );
+  });
+});

--- a/tests/integration/components/cyod-viewer-test.js
+++ b/tests/integration/components/cyod-viewer-test.js
@@ -251,12 +251,12 @@ module('Integration | Component | cyod-viewer', function (hooks) {
 
     await render(TEMPLATE);
 
-    assert.dom(selectors.error).exists('the failure is reported');
     assert
       .dom(selectors.error)
       .hasTextContaining(t('cyod.viewer.connectionFailed'));
     assert.dom(selectors.canvas).exists('the canvas survives the error state');
-    assert.dom(selectors.retryBtn).exists();
+    assert.dom(selectors.retryBtn).hasText(t('cyod.viewer.retry'));
+    assert.dom(selectors.retryBtn).isNotDisabled();
 
     shouldThrow = false;
 

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -285,8 +285,8 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
     };
   });
 
-  test('PROXY_CYOD + INSTALLING shows download link', async function (assert) {
-    const scan = createCyodScan(
+  test('PROXY_CYOD + INSTALLING does not offer a manual install', async function (assert) {
+    createCyodScan(
       this,
       'withProxyCyodDevice',
       ENUMS.DYNAMIC_SCAN_STATUS.INSTALLING
@@ -294,11 +294,11 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
 
     await render(TEMPLATE);
 
-    assert.dom(selectors.cyodDownload).exists();
-
-    assert
-      .dom(selectors.cyodDownloadLink)
-      .hasAttribute('href', scan.device_used.android_download_url);
+    // The manual install prompt is disabled (MANUAL_INSTALL_ENABLED), so a
+    // proxy scan falls through to its viewer instead.
+    assert.dom(selectors.cyodDownload).doesNotExist();
+    assert.dom(selectors.cyodDownloadLink).doesNotExist();
+    assert.dom(selectors.cyodViewer).exists();
   });
 
   test('PROXY_CYOD + READY shows CyodViewer', async function (assert) {
@@ -314,8 +314,8 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
     assert.dom(selectors.cyodReady).doesNotExist();
   });
 
-  test('REMOTE_CYOD + INSTALLING shows iOS install link', async function (assert) {
-    const scan = createCyodScan(
+  test('REMOTE_CYOD + INSTALLING does not offer an iOS install link', async function (assert) {
+    createCyodScan(
       this,
       'withRemoteCyodDevice',
       ENUMS.DYNAMIC_SCAN_STATUS.INSTALLING
@@ -323,11 +323,12 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
 
     await render(TEMPLATE);
 
-    assert.dom(selectors.cyodDownload).exists();
-
-    assert
-      .dom(selectors.cyodDownloadLink)
-      .hasAttribute('href', scan.device_used.ios_itms_url);
+    // A remote scan has no viewer to fall through to, so the device screen is
+    // simply empty while the app installs.
+    assert.dom(selectors.cyodDownload).doesNotExist();
+    assert.dom(selectors.cyodDownloadLink).doesNotExist();
+    assert.dom(selectors.cyodViewer).doesNotExist();
+    assert.dom(selectors.deviceScreen).exists();
   });
 
   test('REMOTE_CYOD + READY shows interact on device', async function (assert) {

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -294,8 +294,10 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
 
     await render(TEMPLATE);
 
-    // The manual install prompt is disabled (MANUAL_INSTALL_ENABLED), so a
-    // proxy scan falls through to its viewer instead.
+    // Two independent reasons, both pointing the same way: the manual prompt is
+    // disabled outright (MANUAL_INSTALL_ENABLED), and swapping the viewer out
+    // for it would tear down the stream socket every time a scan passed through
+    // INSTALLING.
     assert.dom(selectors.cyodDownload).doesNotExist();
     assert.dom(selectors.cyodDownloadLink).doesNotExist();
     assert.dom(selectors.cyodViewer).exists();

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -23,6 +23,7 @@ const selectors = {
   cyodDownloadLink: '[data-test-vncViewer-cyodDownloadLink]',
   cyodViewer: '[data-test-vncViewer-cyodViewer]',
   cyodReady: '[data-test-vncViewer-cyodReady]',
+  cyodPreparing: '[data-test-vncViewer-cyodPreparing]',
 };
 
 // ─── Template ──────────────────────────────────────────────────────────────────
@@ -285,7 +286,7 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
     };
   });
 
-  test('PROXY_CYOD + INSTALLING does not offer a manual install', async function (assert) {
+  test('PROXY_CYOD + INSTALLING waits instead of connecting', async function (assert) {
     createCyodScan(
       this,
       'withProxyCyodDevice',
@@ -294,13 +295,49 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
 
     await render(TEMPLATE);
 
-    // Two independent reasons, both pointing the same way: the manual prompt is
-    // disabled outright (MANUAL_INSTALL_ENABLED), and swapping the viewer out
-    // for it would tear down the stream socket every time a scan passed through
-    // INSTALLING.
+    // moriarty starts the stream on the INSTALLING -> READY transition, so
+    // there is nothing to connect to yet. Mounting the viewer here opened a
+    // socket against a source that did not exist and reported it as a failure.
+    assert.dom(selectors.cyodPreparing).exists();
+    assert.dom(selectors.cyodViewer).doesNotExist();
+
+    // And the manual prompt is disabled outright (MANUAL_INSTALL_ENABLED), so
+    // neither path is offered while the server installs.
     assert.dom(selectors.cyodDownload).doesNotExist();
     assert.dom(selectors.cyodDownloadLink).doesNotExist();
+  });
+
+  test('PROXY_CYOD + AUTOPILOT_RUNNING keeps the viewer mounted', async function (assert) {
+    createCyodScan(
+      this,
+      'withProxyCyodDevice',
+      ENUMS.DYNAMIC_SCAN_STATUS.AUTOPILOT_RUNNING
+    );
+
+    await render(TEMPLATE);
+
     assert.dom(selectors.cyodViewer).exists();
+    assert.dom(selectors.cyodPreparing).doesNotExist();
+  });
+
+  // Stopping a scan tears the Mercer source down (moriarty stop_screen_stream),
+  // so anything still holding the socket open can only watch it close. The
+  // viewer has to come out of the DOM with it, otherwise its reconnect attempts
+  // exhaust and it reports a connection failure for a scan that simply ended.
+  [
+    ['STOP_SCAN_REQUESTED', ENUMS.DYNAMIC_SCAN_STATUS.STOP_SCAN_REQUESTED],
+    ['SHUTTING_DOWN', ENUMS.DYNAMIC_SCAN_STATUS.SHUTTING_DOWN],
+    ['CANCELLED', ENUMS.DYNAMIC_SCAN_STATUS.CANCELLED],
+    ['ANALYZING', ENUMS.DYNAMIC_SCAN_STATUS.ANALYZING],
+  ].forEach(([label, status]) => {
+    test(`PROXY_CYOD + ${label} unmounts the viewer`, async function (assert) {
+      createCyodScan(this, 'withProxyCyodDevice', status);
+
+      await render(TEMPLATE);
+
+      assert.dom(selectors.cyodViewer).doesNotExist();
+      assert.dom(selectors.cyodPreparing).doesNotExist();
+    });
   });
 
   test('PROXY_CYOD + READY shows CyodViewer', async function (assert) {

--- a/tests/integration/components/vnc-viewer-test.js
+++ b/tests/integration/components/vnc-viewer-test.js
@@ -2,7 +2,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 
 import ENUMS from 'irene/enums';
@@ -24,6 +24,7 @@ const selectors = {
   cyodViewer: '[data-test-vncViewer-cyodViewer]',
   cyodReady: '[data-test-vncViewer-cyodReady]',
   cyodPreparing: '[data-test-vncViewer-cyodPreparing]',
+  cyodPreparingLoader: '[data-test-vncViewer-cyodPreparingLoader]',
 };
 
 // ─── Template ──────────────────────────────────────────────────────────────────
@@ -298,7 +299,8 @@ module('Integration | Component | vnc-viewer | CYOD scans', function (hooks) {
     // moriarty starts the stream on the INSTALLING -> READY transition, so
     // there is nothing to connect to yet. Mounting the viewer here opened a
     // socket against a source that did not exist and reported it as a failure.
-    assert.dom(selectors.cyodPreparing).exists();
+    assert.dom(selectors.cyodPreparing).hasText(t('cyod.viewer.preparing'));
+    assert.dom(selectors.cyodPreparingLoader).exists();
     assert.dom(selectors.cyodViewer).doesNotExist();
 
     // And the manual prompt is disabled outright (MANUAL_INSTALL_ENABLED), so

--- a/translations/en.json
+++ b/translations/en.json
@@ -1982,7 +1982,8 @@
     "viewer": {
       "connectionFailed": "Connection failed",
       "unsupportedBrowser": "Screen streaming needs Chrome 94 or newer.",
-      "retry": "Retry"
+      "retry": "Retry",
+      "preparing": "Preparing the device stream..."
     },
     "autoInstall": {
       "ready": "Device connected — ready to install automatically",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1981,7 +1981,8 @@
     "iosAgentNotFound": "iOS agent not found. Please ensure KnoxOps agent is running on this machine.",
     "viewer": {
       "connectionFailed": "Connection failed",
-      "unsupportedBrowser": "Screen streaming needs Chrome 94 or newer."
+      "unsupportedBrowser": "Screen streaming needs Chrome 94 or newer.",
+      "retry": "Retry"
     },
     "autoInstall": {
       "ready": "Device connected — ready to install automatically",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1982,7 +1982,8 @@
     "viewer": {
       "connectionFailed": "接続に失敗しました",
       "unsupportedBrowser": "画面ストリーミングにはChrome 94以降が必要です。",
-      "retry": "Retry"
+      "retry": "Retry",
+      "preparing": "デバイスストリームを準備しています..."
     },
     "autoInstall": {
       "ready": "デバイスが接続されました — 自動インストールの準備ができました",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -1981,7 +1981,8 @@
     "iosAgentNotFound": "iOSエージェントが見つかりません。KnoxOpsエージェントが起動していることを確認してください。",
     "viewer": {
       "connectionFailed": "接続に失敗しました",
-      "unsupportedBrowser": "画面ストリーミングにはChrome 94以降が必要です。"
+      "unsupportedBrowser": "画面ストリーミングにはChrome 94以降が必要です。",
+      "retry": "Retry"
     },
     "autoInstall": {
       "ready": "デバイスが接続されました — 自動インストールの準備ができました",


### PR DESCRIPTION
## What

Two related CYOD fixes to the dynamic-scan device screen:

1. **Disables the manual install prompt** — the screen reading **"Install the app on your device to continue"** with a download / `itms-services://` link. CYOD installs the app server-side, so a scan sat on that prompt while the server was already installing.
2. **Fixes the screen viewer's stream lifecycle** — the viewer showed **"Connection failed"** both while a scan was still starting and again after it had been cancelled.

## 1 — Manual install prompt

One flag in `app/components/vnc-viewer/index.ts`:

```ts
const MANUAL_INSTALL_ENABLED = false;
```

Covers all three variants it fronted: the WebUSB auto-install prompt, the Android APK download link, and the iOS OTA link.

**Nothing is removed.** The markup, the getters (`isWebusbCyod`, `webusbAdb`, `cyodDownloadUrl`, `cyodIsIos`), the `autoInstallViaWebUsb` task and `VncViewer::CyodDownloadLink` all stay. Flip the constant back to `true` to restore it exactly.

## 2 — Stream lifecycle

**The viewer was mounted on a device-capability check with no scan-status term:**

```js
get isScrcpyScan() {
  return deviceUsed?.vnc_mode === ENUMS.DEVICE_VNC_MODE.SCRCPY;
}
```

But moriarty only runs the Mercer relay inside a narrow window — it starts it on the `INSTALLING → READY_FOR_INTERACTION` transition (`start_proxy_screen_stream`) and tears it down on the stop request (`stop_screen_stream`). Outside that window the browser dialled a source that did not exist, which the viewer could only report as a connection failure.

Gated on `isReadyOrRunning`, matching how `NovncRfb` is gated two branches down in the same template — it was the only viewer in the file without a status gate.

**Plus the socket lifecycle itself**, which produced `WebSocket is closed before the connection is established` ×2 on every load:

- handlers detached **before** `close()`, so tearing down a still-`CONNECTING` socket cannot queue a reconnect for an element being destroyed
- every handler confirms it is still the live socket, so a superseded connection cannot report its failure over its replacement
- the canvas stays mounted in every state; status is drawn in an overlay, because swapping the canvas out destroys the modifier that owns the socket
- `new WebSocket()` wrapped — it throws synchronously on a bad URL, on the modifier's install path
- capped exponential backoff plus a **Retry** control, so exhausting the attempts no longer needs a page refresh

## Behaviour

| Scan | `INSTALLING` | `READY` / running | cancelled / shutting down |
|---|---|---|---|
| `PROXY_CYOD` (scrcpy) | preparing note | live viewer | viewer unmounted |
| `REMOTE_CYOD` | empty device screen | "Interact on your device" | — |

## Test plan

- [x] `ember test --filter="cyod-viewer"` — 8/8
- [x] `ember test --filter="vnc-viewer"` — 16/16
- [x] `ember-template-lint`, `tsc --noEmit`, `eslint` clean (5 pre-existing `no-non-null-assertion` warnings in the H.264 byte parsing)
- [x] en/ja translation keys verified at parity
- [ ] Manual: start a CYOD scan on staging — no install prompt while the server installs, viewer appears at `READY`, no "Connection failed" on start or after cancel

## Notes

Based on `feat/cyod-combined`, not `master`.

`needsManualInstall` deliberately keeps **both** terms — `manualInstallEnabled && … && !isScrcpyScan`. The flag and the scrcpy guard were written on separate branches that both rewrote the same condition; either alone is silently wrong, since dropping the flag re-enables the prompt this PR disables, and dropping the guard tears down a live stream socket.

Reviewed against the repo's own `write-component`, `write-tests`, `add-translations` and `component-scss-refactor` conventions.
